### PR TITLE
Feature/additional hdf5

### DIFF
--- a/apps/c/CloverLeaf/Makefile
+++ b/apps/c/CloverLeaf/Makefile
@@ -42,7 +42,7 @@ ifdef DEBUG
   CCFLAGS	= -O0 -g -no-prec-div -openmp -fp-model strict -fp-model source -prec-div -prec-sqrt -DMPICH_IGNORE_CXX_SEEK #-DOPS_DEBUG
 else
   #CCFLAGS	= -O3 -ipo -no-prec-div -fp-model strict -fp-model source -prec-div -prec-sqrt -vec-report2 -xSSE4.2 -parallel #-DCOMM_PERF #-DDEBUG
-  CCFLAGS	= -O3 -ipo -no-prec-div -restrict -fno-alias -fp-model strict -fp-model source -prec-div -prec-sqrt -DMPICH_IGNORE_CXX_SEEK -vec-report #-qopt-report=5 # -vec-report
+  CCFLAGS	= -O3 -no-prec-div -restrict -fno-alias -fp-model strict -fp-model source -prec-div -prec-sqrt -DMPICH_IGNORE_CXX_SEEK -vec-report #-qopt-report=5 # -vec-report
 endif
   CPPFLAGS	= $(CCFLAGS)
   OMPFLAGS	= -openmp #-openmp-report2

--- a/apps/c/CloverLeaf/test.sh
+++ b/apps/c/CloverLeaf/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#set -e
 cd ../../../ops/c
 source ../source_intel
 make

--- a/apps/c/CloverLeaf_3D/Makefile
+++ b/apps/c/CloverLeaf_3D/Makefile
@@ -108,13 +108,18 @@ endif
 endif
 
 
+
 ifdef HDF5_INSTALL_PATH
-  HDF5_INC 	  	:= -DCHECKPOINTING -I$(HDF5_INSTALL_PATH)/include
-  HDF5_LIB 	  	:= -L$(HDF5_INSTALL_PATH)/lib -lhdf5_hl -lhdf5 -lz
+  HDF5_INC              := -I$(HDF5_INSTALL_PATH)/include
+  HDF5_LIB              := -L$(HDF5_INSTALL_PATH)/lib -lhdf5_hl -lhdf5 -lz
   CC = $(MPICC)
   CPP = $(MPICPP)
   OPS_INC += $(HDF5_INC)
+ifdef CHECKPOINTING
+  HDF5_INC              := $(HDF5_INC) -DCHECKPOINTING
 endif
+endif
+
 
 NVCC  := $(CUDA_INSTALL_PATH)/bin/nvcc
 # flags for nvcc

--- a/apps/c/CloverLeaf_3D/build_field.cpp
+++ b/apps/c/CloverLeaf_3D/build_field.cpp
@@ -97,17 +97,17 @@ void build_field()
   work_array6    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array6");
   work_array7    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array7");
 
-  size[0] = x_cells+6; size[1] = y_cells+5; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_x  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_x");
   mass_flux_x = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_x");
   xarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "xarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+6; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_y  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_y");
   mass_flux_y = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_y");
   yarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "yarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+6;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_z  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_z");
   mass_flux_z = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_z");
   zarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "zarea");

--- a/apps/c/CloverLeaf_3D/test.sh
+++ b/apps/c/CloverLeaf_3D/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -e
 cd ../../../ops/c
 ls ../
 source ../source_intel

--- a/apps/c/CloverLeaf_3D_HDF5/Makefile
+++ b/apps/c/CloverLeaf_3D_HDF5/Makefile
@@ -426,4 +426,4 @@ cloverleaf_mpi_opencl: ./OpenCL/cloverleaf_mpi_opencl_kernels.o clover_leaf_ops.
 #
 
 clean:
-	rm -f generate_file cloverleaf_dev_seq cloverleaf_dev_mpi cloverleaf_mpi cloverleaf_seq cloverleaf_openmp cloverleaf_mpi_openmp cloverleaf_cuda cloverleaf_mpi_cuda cloverleaf_openacc cloverleaf_mpi_openacc ./CUDA/*.o ./OpenACC/*.o *.o cloverleaf_opencl cloverleaf_mpi_opencl ./OpenCL/*.o *.o *.optrpt
+	rm -f generate_file generate_file_mpi cloverleaf_dev_seq cloverleaf_dev_mpi cloverleaf_mpi cloverleaf_seq cloverleaf_openmp cloverleaf_mpi_openmp cloverleaf_cuda cloverleaf_mpi_cuda cloverleaf_openacc cloverleaf_mpi_openacc ./CUDA/*.o ./OpenACC/*.o *.o cloverleaf_opencl cloverleaf_mpi_opencl ./OpenCL/*.o *.o *.optrpt

--- a/apps/c/CloverLeaf_3D_HDF5/advec_mom.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/advec_mom.cpp
@@ -219,5 +219,4 @@ void advec_mom(int which_vel, int sweep_number, int dir)
         ops_arg_dat(work_array5/*mom_flux*/, 1, S3D_000_00M1, "double", OPS_READ));
 
   }
-
 }

--- a/apps/c/CloverLeaf_3D_HDF5/advec_mom_ops.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/advec_mom_ops.cpp
@@ -312,5 +312,4 @@ void advec_mom(int which_vel, int sweep_number, int dir)
                  ops_arg_dat(work_array5, 1, S3D_000_00M1, "double", OPS_READ));
 
   }
-
 }

--- a/apps/c/CloverLeaf_3D_HDF5/build_field.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/build_field.cpp
@@ -97,17 +97,17 @@ void build_field()
   work_array6    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array6");
   work_array7    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array7");
 
-  size[0] = x_cells+6; size[1] = y_cells+5; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_x  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_x");
   mass_flux_x = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_x");
   xarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "xarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+6; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_y  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_y");
   mass_flux_y = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_y");
   yarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "yarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+6;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_z  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_z");
   mass_flux_z = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_z");
   zarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "zarea");

--- a/apps/c/CloverLeaf_3D_HDF5/build_field_hdf5.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/build_field_hdf5.cpp
@@ -92,17 +92,17 @@ void build_field_hdf5()
   work_array6    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array6");
   work_array7    = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "work_array7");
 
-  size[0] = x_cells+6; size[1] = y_cells+5; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_x  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_x");
   mass_flux_x = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_x");
   xarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "xarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+6; size[2] = z_cells+5;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_y  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_y");
   mass_flux_y = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_y");
   yarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "yarea");
 
-  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+6;
+  size[0] = x_cells+5; size[1] = y_cells+5; size[2] = z_cells+5;
   vol_flux_z  = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "vol_flux_z");
   mass_flux_z = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "mass_flux_z");
   zarea       = ops_decl_dat(clover_grid, 1, size, base, d_m, d_p, temp, "double", "zarea");

--- a/apps/c/CloverLeaf_3D_HDF5/clover_leaf.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/clover_leaf.cpp
@@ -228,6 +228,8 @@ int main(int argc, char **argv)
   ops_printf("\nTotal Wall time %lf\n",et1-et0);
   ops_fprintf(g_out,"\nTotal Wall time %lf\n",et1-et0);
 
+  ops_dump_to_hdf5("dump.h5");
+
   fclose(g_out);
   ops_exit();
 }

--- a/apps/c/CloverLeaf_3D_HDF5/clover_leaf_ops.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/clover_leaf_ops.cpp
@@ -178,6 +178,8 @@ int main(int argc, char **argv)
   ops_printf("\nTotal Wall time %lf\n",et1-et0);
   ops_fprintf(g_out,"\nTotal Wall time %lf\n",et1-et0);
 
+  ops_dump_to_hdf5("dump.h5");
+
   fclose(g_out);
   ops_exit();
 }

--- a/apps/c/CloverLeaf_3D_HDF5/data.h
+++ b/apps/c/CloverLeaf_3D_HDF5/data.h
@@ -204,4 +204,4 @@ extern ops_reduction red_ke;
 extern ops_reduction red_press;
 extern ops_reduction red_output;
 
-#endif /* #ifndef __CLOVER_LEAF_DATA_H*/
+#endif

--- a/apps/c/CloverLeaf_3D_HDF5/definitions.h
+++ b/apps/c/CloverLeaf_3D_HDF5/definitions.h
@@ -59,5 +59,4 @@ extern double dtold, dt, clover_time, dtinit, dtmin, dtmax, dtrise, dtu_safe, dt
 
 extern int jdt, kdt, ldt;
 
-
-#endif /* __CLOVER_LEAF_DEFINITIONS_H */
+#endif

--- a/apps/c/CloverLeaf_3D_HDF5/generate_chunk_kernel.h
+++ b/apps/c/CloverLeaf_3D_HDF5/generate_chunk_kernel.h
@@ -86,6 +86,4 @@ void generate_chunk_kernel( const double *vertexx,
     }
   }
 }
-
-
 #endif

--- a/apps/c/CloverLeaf_3D_HDF5/generate_hdf5.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/generate_hdf5.cpp
@@ -72,4 +72,5 @@ void generate_hdf5()
     ops_fetch_dat_hdf5_file(xvel0, "cloverdata.h5");
     ops_fetch_dat_hdf5_file(yvel0, "cloverdata.h5");
     ops_fetch_dat_hdf5_file(zvel0, "cloverdata.h5");
+
   }

--- a/apps/c/CloverLeaf_3D_HDF5/test.sh
+++ b/apps/c/CloverLeaf_3D_HDF5/test.sh
@@ -7,6 +7,11 @@ make
 cd -
 make clean
 make
+#============================ Generate HDF5 file ==========================================================
+echo '============> Generate HDF5 file'
+./generate_file
+#rm cloverdata.h5
+
 #============================ Test Cloverleaf 3D ==========================================================
 echo '============> Running OpenMP'
 KMP_AFFINITY=compact OMP_NUM_THREADS=20 ./cloverleaf_openmp > perf_out

--- a/apps/c/CloverLeaf_3D_HDF5/test.sh
+++ b/apps/c/CloverLeaf_3D_HDF5/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -e
 cd ../../../ops/c
 ls ../
 source ../source_intel
@@ -9,8 +9,8 @@ make clean
 make
 #============================ Generate HDF5 file ==========================================================
 echo '============> Generate HDF5 file'
+rm cloverdata.h5
 ./generate_file
-#rm cloverdata.h5
 
 #============================ Test Cloverleaf 3D ==========================================================
 echo '============> Running OpenMP'

--- a/apps/c/CloverLeaf_3D_HDF5/user_types.h
+++ b/apps/c/CloverLeaf_3D_HDF5/user_types.h
@@ -68,5 +68,4 @@ inline int type_error (const state_type * a, const char *type ) {
   (void)a; return (strcmp ( type, "state_type" ) && strcmp ( type, "state_type:soa" ));
 }
 #endif
-
 #endif

--- a/apps/c/multiDim/Makefile
+++ b/apps/c/multiDim/Makefile
@@ -141,7 +141,7 @@ endif
 all: clean $(TARGETS)
 
 multidim_dev_seq: Makefile multidim.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_seq.a
-	$(CPP) $(CPPFLAGS) $(OPS_INC) $(OPS_LIB) multidim.cpp -lops_seq -o multidim_dev_seq
+	$(MPICPP) $(CPPFLAGS) $(OPS_INC) $(HDF5_INC) $(OPS_LIB) multidim.cpp -lops_seq $(HDF5_LIB) -o multidim_dev_seq
 
 
 multidim_dev_mpi: Makefile multidim.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_mpi.a
@@ -166,20 +166,20 @@ multidim_mpi_openmp: Makefile multidim_ops.cpp multidim_kernel.h multidim_print_
 
 
 multidim_openmp: Makefile multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_seq.a
-	$(CPP) $(OMPFLAGS) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) multidim_ops.cpp -I. ./MPI_OpenMP/$(OMP_KERNELS) -lops_seq -o multidim_openmp
+	$(MPICPP) $(OMPFLAGS) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) multidim_ops.cpp -I. ./MPI_OpenMP/$(OMP_KERNELS) -lops_seq $(HDF5_LIB) -o multidim_openmp
 
 #
 # Sequential version
 #
 multidim_seq: Makefile multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_seq.a
-	$(CPP) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) multidim_ops.cpp -I. ./MPI/$(SEQ_KERNELS) -lops_seq -o multidim_seq
+	$(MPICPP) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) multidim_ops.cpp -I. ./MPI/$(SEQ_KERNELS) -lops_seq $(HDF5_LIB) -o multidim_seq
 
 #
 # CUDA version
 #
 
 multidim_cuda: Makefile ./CUDA/multidim_kernels_cu.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_cuda.a
-	$(CPP) $(OMPFLAGS) $(CPPFLAGS) $(CUDA_INC) $(OPS_INC) $(OPS_LIB) $(CUDA_LIB) multidim_ops.cpp ./CUDA/multidim_kernels_cu.o -lcudart -lops_cuda -o multidim_cuda
+	$(MPICPP) $(OMPFLAGS) $(CPPFLAGS) $(CUDA_INC) $(OPS_INC) $(OPS_LIB) $(CUDA_LIB) multidim_ops.cpp ./CUDA/multidim_kernels_cu.o -lcudart -lops_cuda $(HDF5_LIB) -o multidim_cuda
 
 multidim_mpi_cuda: Makefile ./CUDA/multidim_kernels_mpi_cu.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h $(OPS_INSTALL_PATH)/lib/libops_mpi_cuda.a
 	$(MPICPP) $(OMPFLAGS) $(CPPFLAGS) -DOPS_MPI $(CUDA_INC) $(OPS_INC) $(HDF5_INC) $(OPS_LIB) $(CUDA_LIB) multidim_ops.cpp ./CUDA/multidim_kernels_mpi_cu.o -lcudart -lops_mpi_cuda $(HDF5_LIB) -o multidim_mpi_cuda
@@ -223,7 +223,7 @@ openacc_mpi_c_obj_list = $(shell find OpenACC/ -name "*_c.c" | sed s/\\.c/\\_mpi
 
 multidim_openacc: $(openacc_obj_list) ./OpenACC/multidim_kernels.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h Makefile $(OPS_INSTALL_PATH)/lib/libops_cuda.a
 	$(MPICPP) -acc -ta=tesla:cc35 $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) -DOPS_MPI $(CUDA_INC) $(CUDA_LIB) \
-    multidim_ops.cpp -I. $(openacc_obj_list) $(openacc_c_obj_list) -lcudart -lops_cuda -o multidim_openacc
+    multidim_ops.cpp -I. $(openacc_obj_list) $(openacc_c_obj_list) -lcudart -lops_cuda $(HDF5_LIB) -o multidim_openacc
 
 
 multidim_mpi_openacc: $(openacc_mpi_obj_list) ./OpenACC/multidim_kernels_mpi.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h Makefile $(OPS_INSTALL_PATH)/lib/libops_mpi_cuda.a
@@ -235,7 +235,7 @@ multidim_mpi_openacc: $(openacc_mpi_obj_list) ./OpenACC/multidim_kernels_mpi.o m
 #OpenCL version
 #
 multidim_opencl: ./OpenCL/multidim_opencl_kernels.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h Makefile $(OPS_INSTALL_PATH)/lib/libops_opencl.a
-	$(CPP) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) $(OPENCL_LIB) multidim_ops.cpp ./OpenCL/multidim_opencl_kernels.o  -lops_opencl -o multidim_opencl
+	$(MPICPP) $(MPIFLAGS) $(OPS_INC) $(OPS_LIB) $(OPENCL_LIB) multidim_ops.cpp ./OpenCL/multidim_opencl_kernels.o  -lops_opencl $(HDF5_LIB) -o multidim_opencl
 
 
 multidim_mpi_opencl: ./OpenCL/multidim_mpi_opencl_kernels.o multidim_ops.cpp multidim_kernel.h multidim_print_kernel.h multidim_copy_kernel.h Makefile $(OPS_INSTALL_PATH)/lib/libops_mpi_opencl.a

--- a/apps/c/multiDim/multidim.cpp
+++ b/apps/c/multiDim/multidim.cpp
@@ -127,6 +127,10 @@ int main(int argc, char **argv)
 
   ops_timers(&ct1, &et1);
   ops_print_dat_to_txtfile(dat0, "multidim.dat");
+
+  ops_fetch_block_hdf5_file(grid2D, "multidim.h5");
+  ops_fetch_dat_hdf5_file(dat0, "multidim.h5");
+
   ops_printf("\nTotal Wall time %lf\n",et1-et0);
 
   ops_exit();

--- a/apps/c/multiDim/multidim_ops.cpp
+++ b/apps/c/multiDim/multidim_ops.cpp
@@ -93,6 +93,10 @@ int main(int argc, char **argv)
 
   ops_timers(&ct1, &et1);
   ops_print_dat_to_txtfile(dat0, "multidim.dat");
+
+  ops_fetch_block_hdf5_file(grid2D, "multidim.h5");
+  ops_fetch_dat_hdf5_file(dat0, "multidim.h5");
+
   ops_printf("\nTotal Wall time %lf\n",et1-et0);
 
   ops_exit();

--- a/apps/c/multiDim/test.sh
+++ b/apps/c/multiDim/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -e
 cd ../../../ops/c
 source ../source_intel
 make

--- a/apps/c/poisson/test.sh
+++ b/apps/c/poisson/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -e
 cd ../../../ops/c
 source ../source_intel
 make

--- a/apps/c/shsgc/Makefile
+++ b/apps/c/shsgc/Makefile
@@ -71,7 +71,7 @@ ifeq ($(OPS_COMPILER),pgi)
 ifdef DEBUG
   CCFLAGS   = -O0 -Minline -Kieee -Minform=inform -Minfo=all -DOPS_DEBUG
 else
-  CCFLAGS   = -O3 -Kieee -Minline -Minform=severe -Minfo=all
+  CCFLAGS   = -O3 -Kieee -Minline #-Minform=severe -Minfo=all
 endif
   CPPFLAGS  = $(CCFLAGS)
   OMPFLAGS  = -mp

--- a/apps/c/shsgc/test.sh
+++ b/apps/c/shsgc/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#set -e
 cd ../../../ops/c
 source ../source_intel
 make

--- a/ops/c/include/ops_hdf5.h
+++ b/ops/c/include/ops_hdf5.h
@@ -65,7 +65,5 @@ void ops_read_dat_hdf5(ops_dat dat);
 #ifdef __cplusplus
 }
 #endif
-
-
-
-#endif /* __OPS_HDF5_H */
+#endif
+/* __OPS_HDF5_H */

--- a/ops/c/include/ops_hdf5.h
+++ b/ops/c/include/ops_hdf5.h
@@ -61,6 +61,7 @@ void ops_fetch_block_hdf5_file(ops_block block, char const *file_name);
 void ops_fetch_stencil_hdf5_file(ops_stencil stencil, char const *file_name);
 void ops_fetch_halo_hdf5_file(ops_halo halo, char const *file_name);
 void ops_read_dat_hdf5(ops_dat dat);
+void ops_dump_to_hdf5(char const *file_name);
 
 #ifdef __cplusplus
 }

--- a/ops/c/include/ops_lib_core.h
+++ b/ops/c/include/ops_lib_core.h
@@ -290,10 +290,12 @@ extern int OPS_block_index, OPS_block_max,
            OPS_dat_index, OPS_dat_max,
            OPS_halo_group_index, OPS_halo_group_max,
            OPS_halo_index, OPS_halo_max,
-           OPS_reduction_index, OPS_reduction_max;
+           OPS_reduction_index, OPS_reduction_max,
+           OPS_stencil_index;
 extern ops_reduction * OPS_reduction_list;
 
 extern ops_block_descriptor * OPS_block_list;
+extern ops_stencil * OPS_stencil_list;
 extern ops_halo * OPS_halo_list;
 extern ops_halo_group * OPS_halo_group_list;
 extern Double_linked_list OPS_dat_list; //Head of the double linked list

--- a/ops/c/src/externlib/ops_hdf5.c
+++ b/ops/c/src/externlib/ops_hdf5.c
@@ -248,9 +248,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
   for (int d = 0; d < block->dims; d++) {
 	//pure data size (i.e. without block halos) to be noted as an attribute
 	gbl_size[d] = dat->size[d] + dat->d_m[d] - dat->d_p[d];
+
 	//the number of elements thats actually written
 	g_size[d] = dat->size[d];
   }
+
+  //make sure we multiply by the number of data values per element (i.e. dat->dim)
+  g_size[1] = g_size[1]*dat->dim;
 
   //Set up file access property list with parallel I/O access
   plist_id = H5Pcreate(H5P_FILE_ACCESS);

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -1379,3 +1379,36 @@ void ops_read_dat_hdf5(ops_dat dat) {
   }
   return;
 }
+
+
+/*******************************************************************************
+* Routine to dump all ops_blocks, ops_dats etc to a named
+* HDF5 file
+*******************************************************************************/
+
+void ops_dump_to_hdf5(char const *file_name) {
+
+  ops_dat_entry *item;
+  for ( int n = 0; n < OPS_block_index; n++ ) {
+    printf ( "Dumping block %15s to HDF5 file %s\n", OPS_block_list[n].block->name, file_name);
+    ops_fetch_block_hdf5_file(OPS_block_list[n].block, file_name);
+  }
+
+  TAILQ_FOREACH(item, &OPS_dat_list, entries) {
+    printf ( "Dumping dat %15s to HDF5 file %s\n", (item->dat)->name, file_name);
+    if (item->dat->e_dat != 1) //currently cannot write edge dats .. need to fix this
+      ops_fetch_dat_hdf5_file(item->dat, file_name);
+  }
+
+  for ( int i = 0; i < OPS_stencil_index; i++ ) {
+    printf ( "Dumping stencil %15s to HDF5 file %s\n", OPS_stencil_list[i]->name, file_name);
+    ops_fetch_stencil_hdf5_file(OPS_stencil_list[i], file_name);
+  }
+
+  printf("halo index = %d \n",OPS_halo_index);
+  for (int i = 0; i < OPS_halo_index; i++) {
+    printf ( "Dumping halo %15s--%15s to HDF5 file %s\n",
+    OPS_halo_list[i]->from->name, OPS_halo_list[i]->to->name,file_name);
+    ops_fetch_halo_hdf5_file(OPS_halo_list[i], file_name);
+  }
+}

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -489,6 +489,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
     else if (block->dims == 5)
       remove_mpi_halos5D(dat, size, l_disp, data);
 
+    //make sure we multiply by the number of data values per
+    // element (i.e. dat->dim) to get full size of the data
+    size[0] = size[0]*dat->dim;
+    gbl_size[1] = gbl_size[1]*dat->dim; //**note we are using [1] instead of [0] here !! -- need to test for 3D
+    disp[0] = disp[0]*dat->dim;
+
+
     //MPI variables
     MPI_Info info  = MPI_INFO_NULL;
 
@@ -1244,6 +1251,12 @@ void ops_read_dat_hdf5(ops_dat dat) {
     for (int d = 0; d < dat->block->dims; d++) t_size *= size[d];
     //printf("t_size = %d ",t_size);
     char* data = (char *)malloc(t_size*dat->elem_size);
+
+    //make sure we multiply by the number of
+    //data values per element (i.e. dat->dim) to get full size of the data
+    size[0] = size[0]*dat->dim;
+    gbl_size[1] = gbl_size[1]*dat->dim; //**note we are using [1] instead of [0] here !! -- need to test for 3D
+    disp[0] = disp[0]*dat->dim;
 
 
     //create new communicator

--- a/ops/source_cray
+++ b/ops/source_cray
@@ -1,5 +1,15 @@
-export OPS_COMPILER=cray #for Archer
+export OPS_COMPILER=cray
+
+#Archer
 export OPS_INSTALL_PATH=/home/e159/e159/gihan/work/OPS/OPS/ops
-#export CUDA_INSTALL_PATH=/usr/local/cuda-5.5
-#export MPI_INSTALL_PATH=/opt/cray/craype/2.01/bin/
+export CUDA_INSTALL_PATH=/usr/local/cuda-5.5
+export MPI_INSTALL_PATH=/opt/cray/craype/2.01/bin/
+
+
+#Titan
+module load cudatoolkit
+export OPS_INSTALL_PATH=/lustre/atlas/scratch/gihan/csc103/OPS-GIT/OPS/ops
+export HDF5_INSTALL_PATH=/opt/cray/hdf5-parallel/1.8.14/
+export CUDA_INSTALL_PATH=/opt/nvidia/cudatoolkit6.5/6.5.14-1.0502.9613.6.1/
+export MPI_INSTALL_PATH=/opt/cray/mpt/6.3.0/gni/mpich2-cray/81/include/
 


### PR DESCRIPTION
This pull request is for adding a minor routine for the HDF5 I/O capabilities. Specifically it adds a dump routine to write the ops_blocks, ops_dats etc. to an named HDF5 file.  

It also fixes a bug in the HDF5 code due to ignoring the number of data values per element in an ops_dat (i.e. dat->dim) when writing it to an HDF5 file. This functionality has been tested with the multiDim application, but need further testing through a more realistic application.

There is also some other very minor updates that are self explanatory. 