### PR TITLE
Fix/hdf5

### DIFF
--- a/apps/c/CloverLeaf/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int xdim1, int xdim2, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_nopredict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_nopredict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int xdim1, int xdim2, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_nopredict=%d  -Dxdim1_PdV_kernel_nopredict=%d  -Dxdim2_PdV_kernel_nopredict=%d  -Dxdim3_PdV_kernel_nopredict=%d  -Dxdim4_PdV_kernel_nopredict=%d  -Dxdim5_PdV_kernel_nopredict=%d  -Dxdim6_PdV_kernel_nopredict=%d  -Dxdim7_PdV_kernel_nopredict=%d  -Dxdim8_PdV_kernel_nopredict=%d  -Dxdim9_PdV_kernel_nopredict=%d  -Dxdim10_PdV_kernel_nopredict=%d  -Dxdim11_PdV_kernel_nopredict=%d  -Dxdim12_PdV_kernel_nopredict=%d  -Dxdim13_PdV_kernel_nopredict=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10,xdim11,xdim12,xdim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,20 +176,6 @@ void ops_par_loop_PdV_kernel_nopredict(char const *name, ops_block block, int di
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int xdim1, int xdim2, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_predict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_predict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int xdim1, int xdim2, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_predict=%d  -Dxdim1_PdV_kernel_predict=%d  -Dxdim2_PdV_kernel_predict=%d  -Dxdim3_PdV_kernel_predict=%d  -Dxdim4_PdV_kernel_predict=%d  -Dxdim5_PdV_kernel_predict=%d  -Dxdim6_PdV_kernel_predict=%d  -Dxdim7_PdV_kernel_predict=%d  -Dxdim8_PdV_kernel_predict=%d  -Dxdim9_PdV_kernel_predict=%d  -Dxdim10_PdV_kernel_predict=%d  -Dxdim11_PdV_kernel_predict=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10,xdim11);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,18 +174,6 @@ void ops_par_loop_PdV_kernel_predict(char const *name, ops_block block, int dim,
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/accelerate_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/accelerate_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int xdim1, int xdim2, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/accelerate_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/accelerate_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int xdim1, int xdim2, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_accelerate_kernel=%d  -Dxdim1_accelerate_kernel=%d  -Dxdim2_accelerate_kernel=%d  -Dxdim3_accelerate_kernel=%d  -Dxdim4_accelerate_kernel=%d  -Dxdim5_accelerate_kernel=%d  -Dxdim6_accelerate_kernel=%d  -Dxdim7_accelerate_kernel=%d  -Dxdim8_accelerate_kernel=%d  -Dxdim9_accelerate_kernel=%d  -Dxdim10_accelerate_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,17 +173,6 @@ void ops_par_loop_accelerate_kernel(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_xdir=%d  -Dxdim1_advec_cell_kernel1_xdir=%d  -Dxdim2_advec_cell_kernel1_xdir=%d  -Dxdim3_advec_cell_kernel1_xdir=%d  -Dxdim4_advec_cell_kernel1_xdir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_cell_kernel1_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_ydir=%d  -Dxdim1_advec_cell_kernel1_ydir=%d  -Dxdim2_advec_cell_kernel1_ydir=%d  -Dxdim3_advec_cell_kernel1_ydir=%d  -Dxdim4_advec_cell_kernel1_ydir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_cell_kernel1_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_xdir=%d  -Dxdim1_advec_cell_kernel2_xdir=%d  -Dxdim2_advec_cell_kernel2_xdir=%d  -Dxdim3_advec_cell_kernel2_xdir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_cell_kernel2_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_ydir=%d  -Dxdim1_advec_cell_kernel2_ydir=%d  -Dxdim2_advec_cell_kernel2_ydir=%d  -Dxdim3_advec_cell_kernel2_ydir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_cell_kernel2_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_xdir=%d  -Dxdim1_advec_cell_kernel3_xdir=%d  -Dxdim2_advec_cell_kernel3_xdir=%d  -Dxdim3_advec_cell_kernel3_xdir=%d  -Dxdim4_advec_cell_kernel3_xdir=%d  -Dxdim5_advec_cell_kernel3_xdir=%d  -Dxdim6_advec_cell_kernel3_xdir=%d  -Dxdim7_advec_cell_kernel3_xdir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,14 +169,6 @@ void ops_par_loop_advec_cell_kernel3_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_ydir=%d  -Dxdim1_advec_cell_kernel3_ydir=%d  -Dxdim2_advec_cell_kernel3_ydir=%d  -Dxdim3_advec_cell_kernel3_ydir=%d  -Dxdim4_advec_cell_kernel3_ydir=%d  -Dxdim5_advec_cell_kernel3_ydir=%d  -Dxdim6_advec_cell_kernel3_ydir=%d  -Dxdim7_advec_cell_kernel3_ydir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,14 +169,6 @@ void ops_par_loop_advec_cell_kernel3_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_xdir=%d  -Dxdim1_advec_cell_kernel4_xdir=%d  -Dxdim2_advec_cell_kernel4_xdir=%d  -Dxdim3_advec_cell_kernel4_xdir=%d  -Dxdim4_advec_cell_kernel4_xdir=%d  -Dxdim5_advec_cell_kernel4_xdir=%d  -Dxdim6_advec_cell_kernel4_xdir=%d  -Dxdim7_advec_cell_kernel4_xdir=%d  -Dxdim8_advec_cell_kernel4_xdir=%d  -Dxdim9_advec_cell_kernel4_xdir=%d  -Dxdim10_advec_cell_kernel4_xdir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,17 +173,6 @@ void ops_par_loop_advec_cell_kernel4_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int xdim1, int xdim2,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int xdim1, int xdim2,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_ydir=%d  -Dxdim1_advec_cell_kernel4_ydir=%d  -Dxdim2_advec_cell_kernel4_ydir=%d  -Dxdim3_advec_cell_kernel4_ydir=%d  -Dxdim4_advec_cell_kernel4_ydir=%d  -Dxdim5_advec_cell_kernel4_ydir=%d  -Dxdim6_advec_cell_kernel4_ydir=%d  -Dxdim7_advec_cell_kernel4_ydir=%d  -Dxdim8_advec_cell_kernel4_ydir=%d  -Dxdim9_advec_cell_kernel4_ydir=%d  -Dxdim10_advec_cell_kernel4_ydir=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,17 +173,6 @@ void ops_par_loop_advec_cell_kernel4_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_x_nonvector=%d  -Dxdim1_advec_mom_kernel1_x_nonvector=%d  -Dxdim2_advec_mom_kernel1_x_nonvector=%d  -Dxdim3_advec_mom_kernel1_x_nonvector=%d  -Dxdim4_advec_mom_kernel1_x_nonvector=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel1_x_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_y_nonvector=%d  -Dxdim1_advec_mom_kernel1_y_nonvector=%d  -Dxdim2_advec_mom_kernel1_y_nonvector=%d  -Dxdim3_advec_mom_kernel1_y_nonvector=%d  -Dxdim4_advec_mom_kernel1_y_nonvector=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel1_y_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_x=%d  -Dxdim1_advec_mom_kernel2_x=%d  -Dxdim2_advec_mom_kernel2_x=%d  -Dxdim3_advec_mom_kernel2_x=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_mom_kernel2_x(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_y=%d  -Dxdim1_advec_mom_kernel2_y=%d  -Dxdim2_advec_mom_kernel2_y=%d  -Dxdim3_advec_mom_kernel2_y=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_mom_kernel2_y(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_x=%d  -Dxdim1_advec_mom_kernel_mass_flux_x=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,8 +162,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_x(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_y=%d  -Dxdim1_advec_mom_kernel_mass_flux_y=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,8 +162,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_y(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_x=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_x(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_y=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_y(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x1=%d  -Dxdim1_advec_mom_kernel_x1=%d  -Dxdim2_advec_mom_kernel_x1=%d  -Dxdim3_advec_mom_kernel_x1=%d  -Dxdim4_advec_mom_kernel_x1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel_x1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x2=%d  -Dxdim1_advec_mom_kernel_x2=%d  -Dxdim2_advec_mom_kernel_x2=%d  -Dxdim3_advec_mom_kernel_x2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_mom_kernel_x2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_y1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_y1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_y1(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_y1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_y1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_y1(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_y1=%d  -Dxdim1_advec_mom_kernel_y1=%d  -Dxdim2_advec_mom_kernel_y1=%d  -Dxdim3_advec_mom_kernel_y1=%d  -Dxdim4_advec_mom_kernel_y1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,11 +166,6 @@ void ops_par_loop_advec_mom_kernel_y1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_y2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_y2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_y2=%d  -Dxdim1_advec_mom_kernel_y2=%d  -Dxdim2_advec_mom_kernel_y2=%d  -Dxdim3_advec_mom_kernel_y2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_advec_mom_kernel_y2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_get.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_get.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_get=%d  -Dxdim1_calc_dt_kernel_get=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -196,8 +196,6 @@ void ops_par_loop_calc_dt_kernel_get(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_min.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_min.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_min=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -182,7 +182,6 @@ void ops_par_loop_calc_dt_kernel_min(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int xdim1, int xdim2, int xdim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int xdim1, int xdim2, int xdim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel=%d  -Dxdim1_calc_dt_kernel=%d  -Dxdim2_calc_dt_kernel=%d  -Dxdim3_calc_dt_kernel=%d  -Dxdim4_calc_dt_kernel=%d  -Dxdim5_calc_dt_kernel=%d  -Dxdim6_calc_dt_kernel=%d  -Dxdim7_calc_dt_kernel=%d  -Dxdim8_calc_dt_kernel=%d  -Dxdim9_calc_dt_kernel=%d  -Dxdim10_calc_dt_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8,xdim9,xdim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,17 +173,6 @@ void ops_par_loop_calc_dt_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int xdim1, int xdim2, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_print.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_print.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int xdim1, int xdim2, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_print=%d  -Dxdim1_calc_dt_kernel_print=%d  -Dxdim2_calc_dt_kernel_print=%d  -Dxdim3_calc_dt_kernel_print=%d  -Dxdim4_calc_dt_kernel_print=%d  -Dxdim5_calc_dt_kernel_print=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -188,12 +188,6 @@ void ops_par_loop_calc_dt_kernel_print(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/field_summary_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/field_summary_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int xdim1, int xdim2, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/field_summary_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/field_summary_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int xdim1, int xdim2, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_field_summary_kernel=%d  -Dxdim1_field_summary_kernel=%d  -Dxdim2_field_summary_kernel=%d  -Dxdim3_field_summary_kernel=%d  -Dxdim4_field_summary_kernel=%d  -Dxdim5_field_summary_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -241,12 +241,6 @@ void ops_par_loop_field_summary_kernel(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int xdim1, int xdim2, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernelx.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernelx.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int xdim1, int xdim2, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernelx=%d  -Dxdim1_flux_calc_kernelx=%d  -Dxdim2_flux_calc_kernelx=%d  -Dxdim3_flux_calc_kernelx=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_flux_calc_kernelx(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/flux_calc_kernely_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/flux_calc_kernely_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int xdim1, int xdim2, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernely.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernely.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int xdim1, int xdim2, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernely=%d  -Dxdim1_flux_calc_kernely=%d  -Dxdim2_flux_calc_kernely=%d  -Dxdim3_flux_calc_kernely=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_flux_calc_kernely(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/ideal_gas_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/ideal_gas_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_ideal_gas_kernel=%d  -Dxdim1_ideal_gas_kernel=%d  -Dxdim2_ideal_gas_kernel=%d  -Dxdim3_ideal_gas_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_ideal_gas_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/reset_field_kernel1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/reset_field_kernel1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel1=%d  -Dxdim1_reset_field_kernel1=%d  -Dxdim2_reset_field_kernel1=%d  -Dxdim3_reset_field_kernel1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_reset_field_kernel1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/reset_field_kernel2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/reset_field_kernel2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel2=%d  -Dxdim1_reset_field_kernel2=%d  -Dxdim2_reset_field_kernel2=%d  -Dxdim3_reset_field_kernel2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_reset_field_kernel2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/revert_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/revert_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int xdim1, int xdim2, int xdim3
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/revert_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/revert_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int xdim1, int xdim2, int xdim3
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_revert_kernel=%d  -Dxdim1_revert_kernel=%d  -Dxdim2_revert_kernel=%d  -Dxdim3_revert_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -164,10 +164,6 @@ void ops_par_loop_revert_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b1=%d  -Dxdim1_update_halo_kernel1_b1=%d  -Dxdim2_update_halo_kernel1_b1=%d  -Dxdim3_update_halo_kernel1_b1=%d  -Dxdim4_update_halo_kernel1_b1=%d  -Dxdim5_update_halo_kernel1_b1=%d  -Dxdim6_update_halo_kernel1_b1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_b1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b2=%d  -Dxdim1_update_halo_kernel1_b2=%d  -Dxdim2_update_halo_kernel1_b2=%d  -Dxdim3_update_halo_kernel1_b2=%d  -Dxdim4_update_halo_kernel1_b2=%d  -Dxdim5_update_halo_kernel1_b2=%d  -Dxdim6_update_halo_kernel1_b2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_b2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l1=%d  -Dxdim1_update_halo_kernel1_l1=%d  -Dxdim2_update_halo_kernel1_l1=%d  -Dxdim3_update_halo_kernel1_l1=%d  -Dxdim4_update_halo_kernel1_l1=%d  -Dxdim5_update_halo_kernel1_l1=%d  -Dxdim6_update_halo_kernel1_l1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_l1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l2=%d  -Dxdim1_update_halo_kernel1_l2=%d  -Dxdim2_update_halo_kernel1_l2=%d  -Dxdim3_update_halo_kernel1_l2=%d  -Dxdim4_update_halo_kernel1_l2=%d  -Dxdim5_update_halo_kernel1_l2=%d  -Dxdim6_update_halo_kernel1_l2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_l2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r1=%d  -Dxdim1_update_halo_kernel1_r1=%d  -Dxdim2_update_halo_kernel1_r1=%d  -Dxdim3_update_halo_kernel1_r1=%d  -Dxdim4_update_halo_kernel1_r1=%d  -Dxdim5_update_halo_kernel1_r1=%d  -Dxdim6_update_halo_kernel1_r1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_r1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r2=%d  -Dxdim1_update_halo_kernel1_r2=%d  -Dxdim2_update_halo_kernel1_r2=%d  -Dxdim3_update_halo_kernel1_r2=%d  -Dxdim4_update_halo_kernel1_r2=%d  -Dxdim5_update_halo_kernel1_r2=%d  -Dxdim6_update_halo_kernel1_r2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_r2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t1=%d  -Dxdim1_update_halo_kernel1_t1=%d  -Dxdim2_update_halo_kernel1_t1=%d  -Dxdim3_update_halo_kernel1_t1=%d  -Dxdim4_update_halo_kernel1_t1=%d  -Dxdim5_update_halo_kernel1_t1=%d  -Dxdim6_update_halo_kernel1_t1=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_t1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int xdim1, int xdim2, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int xdim1, int xdim2, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t2=%d  -Dxdim1_update_halo_kernel1_t2=%d  -Dxdim2_update_halo_kernel1_t2=%d  -Dxdim3_update_halo_kernel1_t2=%d  -Dxdim4_update_halo_kernel1_t2=%d  -Dxdim5_update_halo_kernel1_t2=%d  -Dxdim6_update_halo_kernel1_t2=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -179,13 +179,6 @@ void ops_par_loop_update_halo_kernel1_t2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_a(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_a(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_a=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_a(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_b(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_b(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_b=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_b(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_a(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_a(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_a=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_a(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_b(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_b(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_b=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_b(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_a(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_a(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_a=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_a(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_b(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_b(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_b=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_b(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_a(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_a(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_a=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_a(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_xvel_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_b(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_b(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_b=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_b(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_a(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_a(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_a=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_a(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_b(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_b(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_b=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_b(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_a(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_a(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_a=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_a(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_b(int xdim0, int xdim1)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_b(int xdim0, int xdim1)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_b=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_b(char const *name, ops_block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_a(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_a(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_a=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_a(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_b(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_b(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_b=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_b(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_a(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_a(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_a=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_a(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel2_yvel_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_b(int xdim0, int xdim1) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_b(int xdim0, int xdim1) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_b=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_b(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_a=%d  -Dxdim1_update_halo_kernel3_minus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_b=%d  -Dxdim1_update_halo_kernel3_minus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_a=%d  -Dxdim1_update_halo_kernel3_minus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_b=%d  -Dxdim1_update_halo_kernel3_minus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_a=%d  -Dxdim1_update_halo_kernel3_plus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_b=%d  -Dxdim1_update_halo_kernel3_plus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_a=%d  -Dxdim1_update_halo_kernel3_plus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_b=%d  -Dxdim1_update_halo_kernel3_plus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_a=%d  -Dxdim1_update_halo_kernel4_minus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_b=%d  -Dxdim1_update_halo_kernel4_minus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_a=%d  -Dxdim1_update_halo_kernel4_minus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_b=%d  -Dxdim1_update_halo_kernel4_minus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_a=%d  -Dxdim1_update_halo_kernel4_plus_2_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_b=%d  -Dxdim1_update_halo_kernel4_plus_2_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_a=%d  -Dxdim1_update_halo_kernel4_plus_4_a=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_b=%d  -Dxdim1_update_halo_kernel4_plus_4_b=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -173,8 +173,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/OpenCL/viscosity_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenCL/viscosity_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/viscosity_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/viscosity_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_viscosity_kernel=%d  -Dxdim1_viscosity_kernel=%d  -Dxdim2_viscosity_kernel=%d  -Dxdim3_viscosity_kernel=%d  -Dxdim4_viscosity_kernel=%d  -Dxdim5_viscosity_kernel=%d  -Dxdim6_viscosity_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -168,13 +168,6 @@ void ops_par_loop_viscosity_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf/test.sh
+++ b/apps/c/CloverLeaf/test.sh
@@ -65,7 +65,7 @@ rm perf_out
 
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -132,7 +132,7 @@ grep "step:   2955" clover.out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -

--- a/apps/c/CloverLeaf_3D/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_nopredict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_nopredict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_nopredict=%d  -Dydim0_PdV_kernel_nopredict=%d  -Dxdim1_PdV_kernel_nopredict=%d  -Dydim1_PdV_kernel_nopredict=%d  -Dxdim2_PdV_kernel_nopredict=%d  -Dydim2_PdV_kernel_nopredict=%d  -Dxdim3_PdV_kernel_nopredict=%d  -Dydim3_PdV_kernel_nopredict=%d  -Dxdim4_PdV_kernel_nopredict=%d  -Dydim4_PdV_kernel_nopredict=%d  -Dxdim5_PdV_kernel_nopredict=%d  -Dydim5_PdV_kernel_nopredict=%d  -Dxdim6_PdV_kernel_nopredict=%d  -Dydim6_PdV_kernel_nopredict=%d  -Dxdim7_PdV_kernel_nopredict=%d  -Dydim7_PdV_kernel_nopredict=%d  -Dxdim8_PdV_kernel_nopredict=%d  -Dydim8_PdV_kernel_nopredict=%d  -Dxdim9_PdV_kernel_nopredict=%d  -Dydim9_PdV_kernel_nopredict=%d  -Dxdim10_PdV_kernel_nopredict=%d  -Dydim10_PdV_kernel_nopredict=%d  -Dxdim11_PdV_kernel_nopredict=%d  -Dydim11_PdV_kernel_nopredict=%d  -Dxdim12_PdV_kernel_nopredict=%d  -Dydim12_PdV_kernel_nopredict=%d  -Dxdim13_PdV_kernel_nopredict=%d  -Dydim13_PdV_kernel_nopredict=%d  -Dxdim14_PdV_kernel_nopredict=%d  -Dydim14_PdV_kernel_nopredict=%d  -Dxdim15_PdV_kernel_nopredict=%d  -Dydim15_PdV_kernel_nopredict=%d  -Dxdim16_PdV_kernel_nopredict=%d  -Dydim16_PdV_kernel_nopredict=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13,xdim14,ydim14,xdim15,ydim15,xdim16,ydim16);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -198,23 +198,6 @@ void ops_par_loop_PdV_kernel_nopredict(char const *name, ops_block block, int di
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
-  int dat14 = args[14].dat->elem_size;
-  int dat15 = args[15].dat->elem_size;
-  int dat16 = args[16].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int ydim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_predict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_predict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int ydim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_predict=%d  -Dydim0_PdV_kernel_predict=%d  -Dxdim1_PdV_kernel_predict=%d  -Dydim1_PdV_kernel_predict=%d  -Dxdim2_PdV_kernel_predict=%d  -Dydim2_PdV_kernel_predict=%d  -Dxdim3_PdV_kernel_predict=%d  -Dydim3_PdV_kernel_predict=%d  -Dxdim4_PdV_kernel_predict=%d  -Dydim4_PdV_kernel_predict=%d  -Dxdim5_PdV_kernel_predict=%d  -Dydim5_PdV_kernel_predict=%d  -Dxdim6_PdV_kernel_predict=%d  -Dydim6_PdV_kernel_predict=%d  -Dxdim7_PdV_kernel_predict=%d  -Dydim7_PdV_kernel_predict=%d  -Dxdim8_PdV_kernel_predict=%d  -Dydim8_PdV_kernel_predict=%d  -Dxdim9_PdV_kernel_predict=%d  -Dydim9_PdV_kernel_predict=%d  -Dxdim10_PdV_kernel_predict=%d  -Dydim10_PdV_kernel_predict=%d  -Dxdim11_PdV_kernel_predict=%d  -Dydim11_PdV_kernel_predict=%d  -Dxdim12_PdV_kernel_predict=%d  -Dydim12_PdV_kernel_predict=%d  -Dxdim13_PdV_kernel_predict=%d  -Dydim13_PdV_kernel_predict=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_PdV_kernel_predict(char const *name, ops_block block, int dim,
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/accelerate_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/accelerate_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/accelerate_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/accelerate_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_accelerate_kernel=%d  -Dydim0_accelerate_kernel=%d  -Dxdim1_accelerate_kernel=%d  -Dydim1_accelerate_kernel=%d  -Dxdim2_accelerate_kernel=%d  -Dydim2_accelerate_kernel=%d  -Dxdim3_accelerate_kernel=%d  -Dydim3_accelerate_kernel=%d  -Dxdim4_accelerate_kernel=%d  -Dydim4_accelerate_kernel=%d  -Dxdim5_accelerate_kernel=%d  -Dydim5_accelerate_kernel=%d  -Dxdim6_accelerate_kernel=%d  -Dydim6_accelerate_kernel=%d  -Dxdim7_accelerate_kernel=%d  -Dydim7_accelerate_kernel=%d  -Dxdim8_accelerate_kernel=%d  -Dydim8_accelerate_kernel=%d  -Dxdim9_accelerate_kernel=%d  -Dydim9_accelerate_kernel=%d  -Dxdim10_accelerate_kernel=%d  -Dydim10_accelerate_kernel=%d  -Dxdim11_accelerate_kernel=%d  -Dydim11_accelerate_kernel=%d  -Dxdim12_accelerate_kernel=%d  -Dydim12_accelerate_kernel=%d  -Dxdim13_accelerate_kernel=%d  -Dydim13_accelerate_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_accelerate_kernel(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_xdir=%d  -Dydim0_advec_cell_kernel1_xdir=%d  -Dxdim1_advec_cell_kernel1_xdir=%d  -Dydim1_advec_cell_kernel1_xdir=%d  -Dxdim2_advec_cell_kernel1_xdir=%d  -Dydim2_advec_cell_kernel1_xdir=%d  -Dxdim3_advec_cell_kernel1_xdir=%d  -Dydim3_advec_cell_kernel1_xdir=%d  -Dxdim4_advec_cell_kernel1_xdir=%d  -Dydim4_advec_cell_kernel1_xdir=%d  -Dxdim5_advec_cell_kernel1_xdir=%d  -Dydim5_advec_cell_kernel1_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_cell_kernel1_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_ydir=%d  -Dydim0_advec_cell_kernel1_ydir=%d  -Dxdim1_advec_cell_kernel1_ydir=%d  -Dydim1_advec_cell_kernel1_ydir=%d  -Dxdim2_advec_cell_kernel1_ydir=%d  -Dydim2_advec_cell_kernel1_ydir=%d  -Dxdim3_advec_cell_kernel1_ydir=%d  -Dydim3_advec_cell_kernel1_ydir=%d  -Dxdim4_advec_cell_kernel1_ydir=%d  -Dydim4_advec_cell_kernel1_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_cell_kernel1_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel1_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_zdir=%d  -Dydim0_advec_cell_kernel1_zdir=%d  -Dxdim1_advec_cell_kernel1_zdir=%d  -Dydim1_advec_cell_kernel1_zdir=%d  -Dxdim2_advec_cell_kernel1_zdir=%d  -Dydim2_advec_cell_kernel1_zdir=%d  -Dxdim3_advec_cell_kernel1_zdir=%d  -Dydim3_advec_cell_kernel1_zdir=%d  -Dxdim4_advec_cell_kernel1_zdir=%d  -Dydim4_advec_cell_kernel1_zdir=%d  -Dxdim5_advec_cell_kernel1_zdir=%d  -Dydim5_advec_cell_kernel1_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_cell_kernel1_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_xdir=%d  -Dydim0_advec_cell_kernel2_xdir=%d  -Dxdim1_advec_cell_kernel2_xdir=%d  -Dydim1_advec_cell_kernel2_xdir=%d  -Dxdim2_advec_cell_kernel2_xdir=%d  -Dydim2_advec_cell_kernel2_xdir=%d  -Dxdim3_advec_cell_kernel2_xdir=%d  -Dydim3_advec_cell_kernel2_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_cell_kernel2_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_ydir=%d  -Dydim0_advec_cell_kernel2_ydir=%d  -Dxdim1_advec_cell_kernel2_ydir=%d  -Dydim1_advec_cell_kernel2_ydir=%d  -Dxdim2_advec_cell_kernel2_ydir=%d  -Dydim2_advec_cell_kernel2_ydir=%d  -Dxdim3_advec_cell_kernel2_ydir=%d  -Dydim3_advec_cell_kernel2_ydir=%d  -Dxdim4_advec_cell_kernel2_ydir=%d  -Dydim4_advec_cell_kernel2_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_cell_kernel2_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel2_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_zdir=%d  -Dydim0_advec_cell_kernel2_zdir=%d  -Dxdim1_advec_cell_kernel2_zdir=%d  -Dydim1_advec_cell_kernel2_zdir=%d  -Dxdim2_advec_cell_kernel2_zdir=%d  -Dydim2_advec_cell_kernel2_zdir=%d  -Dxdim3_advec_cell_kernel2_zdir=%d  -Dydim3_advec_cell_kernel2_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_cell_kernel2_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_xdir=%d  -Dydim0_advec_cell_kernel3_xdir=%d  -Dxdim1_advec_cell_kernel3_xdir=%d  -Dydim1_advec_cell_kernel3_xdir=%d  -Dxdim2_advec_cell_kernel3_xdir=%d  -Dydim2_advec_cell_kernel3_xdir=%d  -Dxdim3_advec_cell_kernel3_xdir=%d  -Dydim3_advec_cell_kernel3_xdir=%d  -Dxdim4_advec_cell_kernel3_xdir=%d  -Dydim4_advec_cell_kernel3_xdir=%d  -Dxdim5_advec_cell_kernel3_xdir=%d  -Dydim5_advec_cell_kernel3_xdir=%d  -Dxdim6_advec_cell_kernel3_xdir=%d  -Dydim6_advec_cell_kernel3_xdir=%d  -Dxdim7_advec_cell_kernel3_xdir=%d  -Dydim7_advec_cell_kernel3_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_ydir=%d  -Dydim0_advec_cell_kernel3_ydir=%d  -Dxdim1_advec_cell_kernel3_ydir=%d  -Dydim1_advec_cell_kernel3_ydir=%d  -Dxdim2_advec_cell_kernel3_ydir=%d  -Dydim2_advec_cell_kernel3_ydir=%d  -Dxdim3_advec_cell_kernel3_ydir=%d  -Dydim3_advec_cell_kernel3_ydir=%d  -Dxdim4_advec_cell_kernel3_ydir=%d  -Dydim4_advec_cell_kernel3_ydir=%d  -Dxdim5_advec_cell_kernel3_ydir=%d  -Dydim5_advec_cell_kernel3_ydir=%d  -Dxdim6_advec_cell_kernel3_ydir=%d  -Dydim6_advec_cell_kernel3_ydir=%d  -Dxdim7_advec_cell_kernel3_ydir=%d  -Dydim7_advec_cell_kernel3_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel3_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_zdir=%d  -Dydim0_advec_cell_kernel3_zdir=%d  -Dxdim1_advec_cell_kernel3_zdir=%d  -Dydim1_advec_cell_kernel3_zdir=%d  -Dxdim2_advec_cell_kernel3_zdir=%d  -Dydim2_advec_cell_kernel3_zdir=%d  -Dxdim3_advec_cell_kernel3_zdir=%d  -Dydim3_advec_cell_kernel3_zdir=%d  -Dxdim4_advec_cell_kernel3_zdir=%d  -Dydim4_advec_cell_kernel3_zdir=%d  -Dxdim5_advec_cell_kernel3_zdir=%d  -Dydim5_advec_cell_kernel3_zdir=%d  -Dxdim6_advec_cell_kernel3_zdir=%d  -Dydim6_advec_cell_kernel3_zdir=%d  -Dxdim7_advec_cell_kernel3_zdir=%d  -Dydim7_advec_cell_kernel3_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_xdir=%d  -Dydim0_advec_cell_kernel4_xdir=%d  -Dxdim1_advec_cell_kernel4_xdir=%d  -Dydim1_advec_cell_kernel4_xdir=%d  -Dxdim2_advec_cell_kernel4_xdir=%d  -Dydim2_advec_cell_kernel4_xdir=%d  -Dxdim3_advec_cell_kernel4_xdir=%d  -Dydim3_advec_cell_kernel4_xdir=%d  -Dxdim4_advec_cell_kernel4_xdir=%d  -Dydim4_advec_cell_kernel4_xdir=%d  -Dxdim5_advec_cell_kernel4_xdir=%d  -Dydim5_advec_cell_kernel4_xdir=%d  -Dxdim6_advec_cell_kernel4_xdir=%d  -Dydim6_advec_cell_kernel4_xdir=%d  -Dxdim7_advec_cell_kernel4_xdir=%d  -Dydim7_advec_cell_kernel4_xdir=%d  -Dxdim8_advec_cell_kernel4_xdir=%d  -Dydim8_advec_cell_kernel4_xdir=%d  -Dxdim9_advec_cell_kernel4_xdir=%d  -Dydim9_advec_cell_kernel4_xdir=%d  -Dxdim10_advec_cell_kernel4_xdir=%d  -Dydim10_advec_cell_kernel4_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_ydir=%d  -Dydim0_advec_cell_kernel4_ydir=%d  -Dxdim1_advec_cell_kernel4_ydir=%d  -Dydim1_advec_cell_kernel4_ydir=%d  -Dxdim2_advec_cell_kernel4_ydir=%d  -Dydim2_advec_cell_kernel4_ydir=%d  -Dxdim3_advec_cell_kernel4_ydir=%d  -Dydim3_advec_cell_kernel4_ydir=%d  -Dxdim4_advec_cell_kernel4_ydir=%d  -Dydim4_advec_cell_kernel4_ydir=%d  -Dxdim5_advec_cell_kernel4_ydir=%d  -Dydim5_advec_cell_kernel4_ydir=%d  -Dxdim6_advec_cell_kernel4_ydir=%d  -Dydim6_advec_cell_kernel4_ydir=%d  -Dxdim7_advec_cell_kernel4_ydir=%d  -Dydim7_advec_cell_kernel4_ydir=%d  -Dxdim8_advec_cell_kernel4_ydir=%d  -Dydim8_advec_cell_kernel4_ydir=%d  -Dxdim9_advec_cell_kernel4_ydir=%d  -Dydim9_advec_cell_kernel4_ydir=%d  -Dxdim10_advec_cell_kernel4_ydir=%d  -Dydim10_advec_cell_kernel4_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_cell_kernel4_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_zdir=%d  -Dydim0_advec_cell_kernel4_zdir=%d  -Dxdim1_advec_cell_kernel4_zdir=%d  -Dydim1_advec_cell_kernel4_zdir=%d  -Dxdim2_advec_cell_kernel4_zdir=%d  -Dydim2_advec_cell_kernel4_zdir=%d  -Dxdim3_advec_cell_kernel4_zdir=%d  -Dydim3_advec_cell_kernel4_zdir=%d  -Dxdim4_advec_cell_kernel4_zdir=%d  -Dydim4_advec_cell_kernel4_zdir=%d  -Dxdim5_advec_cell_kernel4_zdir=%d  -Dydim5_advec_cell_kernel4_zdir=%d  -Dxdim6_advec_cell_kernel4_zdir=%d  -Dydim6_advec_cell_kernel4_zdir=%d  -Dxdim7_advec_cell_kernel4_zdir=%d  -Dydim7_advec_cell_kernel4_zdir=%d  -Dxdim8_advec_cell_kernel4_zdir=%d  -Dydim8_advec_cell_kernel4_zdir=%d  -Dxdim9_advec_cell_kernel4_zdir=%d  -Dydim9_advec_cell_kernel4_zdir=%d  -Dxdim10_advec_cell_kernel4_zdir=%d  -Dydim10_advec_cell_kernel4_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_x_nonvector=%d  -Dydim0_advec_mom_kernel1_x_nonvector=%d  -Dxdim1_advec_mom_kernel1_x_nonvector=%d  -Dydim1_advec_mom_kernel1_x_nonvector=%d  -Dxdim2_advec_mom_kernel1_x_nonvector=%d  -Dydim2_advec_mom_kernel1_x_nonvector=%d  -Dxdim3_advec_mom_kernel1_x_nonvector=%d  -Dydim3_advec_mom_kernel1_x_nonvector=%d  -Dxdim4_advec_mom_kernel1_x_nonvector=%d  -Dydim4_advec_mom_kernel1_x_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_x_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_y_nonvector=%d  -Dydim0_advec_mom_kernel1_y_nonvector=%d  -Dxdim1_advec_mom_kernel1_y_nonvector=%d  -Dydim1_advec_mom_kernel1_y_nonvector=%d  -Dxdim2_advec_mom_kernel1_y_nonvector=%d  -Dydim2_advec_mom_kernel1_y_nonvector=%d  -Dxdim3_advec_mom_kernel1_y_nonvector=%d  -Dydim3_advec_mom_kernel1_y_nonvector=%d  -Dxdim4_advec_mom_kernel1_y_nonvector=%d  -Dydim4_advec_mom_kernel1_y_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_y_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_z_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel1_z_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_z_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_z_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_z_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_z_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_z_nonvector=%d  -Dydim0_advec_mom_kernel1_z_nonvector=%d  -Dxdim1_advec_mom_kernel1_z_nonvector=%d  -Dydim1_advec_mom_kernel1_z_nonvector=%d  -Dxdim2_advec_mom_kernel1_z_nonvector=%d  -Dydim2_advec_mom_kernel1_z_nonvector=%d  -Dxdim3_advec_mom_kernel1_z_nonvector=%d  -Dydim3_advec_mom_kernel1_z_nonvector=%d  -Dxdim4_advec_mom_kernel1_z_nonvector=%d  -Dydim4_advec_mom_kernel1_z_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_z_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_x=%d  -Dydim0_advec_mom_kernel2_x=%d  -Dxdim1_advec_mom_kernel2_x=%d  -Dydim1_advec_mom_kernel2_x=%d  -Dxdim2_advec_mom_kernel2_x=%d  -Dydim2_advec_mom_kernel2_x=%d  -Dxdim3_advec_mom_kernel2_x=%d  -Dydim3_advec_mom_kernel2_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_x(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_y=%d  -Dydim0_advec_mom_kernel2_y=%d  -Dxdim1_advec_mom_kernel2_y=%d  -Dydim1_advec_mom_kernel2_y=%d  -Dxdim2_advec_mom_kernel2_y=%d  -Dydim2_advec_mom_kernel2_y=%d  -Dxdim3_advec_mom_kernel2_y=%d  -Dydim3_advec_mom_kernel2_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_y(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel2_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_z(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_z(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_z=%d  -Dydim0_advec_mom_kernel2_z=%d  -Dxdim1_advec_mom_kernel2_z=%d  -Dydim1_advec_mom_kernel2_z=%d  -Dxdim2_advec_mom_kernel2_z=%d  -Dydim2_advec_mom_kernel2_z=%d  -Dxdim3_advec_mom_kernel2_z=%d  -Dydim3_advec_mom_kernel2_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_z(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_x=%d  -Dydim0_advec_mom_kernel_mass_flux_x=%d  -Dxdim1_advec_mom_kernel_mass_flux_x=%d  -Dydim1_advec_mom_kernel_mass_flux_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_x(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_y=%d  -Dydim0_advec_mom_kernel_mass_flux_y=%d  -Dxdim1_advec_mom_kernel_mass_flux_y=%d  -Dydim1_advec_mom_kernel_mass_flux_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_y(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_mass_flux_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_z(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_z(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_z=%d  -Dydim0_advec_mom_kernel_mass_flux_z=%d  -Dxdim1_advec_mom_kernel_mass_flux_z=%d  -Dydim1_advec_mom_kernel_mass_flux_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_z(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_x=%d  -Dydim0_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_x=%d  -Dydim1_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_x=%d  -Dydim2_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_x=%d  -Dydim3_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_x=%d  -Dydim4_advec_mom_kernel_post_pre_advec_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_x(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_y=%d  -Dydim0_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_y=%d  -Dydim1_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_y=%d  -Dydim2_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_y=%d  -Dydim3_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_y=%d  -Dydim4_advec_mom_kernel_post_pre_advec_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_y(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_post_pre_advec_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_z(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_z(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_z=%d  -Dydim0_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_z=%d  -Dydim1_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_z=%d  -Dydim2_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_z=%d  -Dydim3_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_z=%d  -Dydim4_advec_mom_kernel_post_pre_advec_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_z(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x1=%d  -Dydim0_advec_mom_kernel_x1=%d  -Dxdim1_advec_mom_kernel_x1=%d  -Dydim1_advec_mom_kernel_x1=%d  -Dxdim2_advec_mom_kernel_x1=%d  -Dydim2_advec_mom_kernel_x1=%d  -Dxdim3_advec_mom_kernel_x1=%d  -Dydim3_advec_mom_kernel_x1=%d  -Dxdim4_advec_mom_kernel_x1=%d  -Dydim4_advec_mom_kernel_x1=%d  -Dxdim5_advec_mom_kernel_x1=%d  -Dydim5_advec_mom_kernel_x1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_mom_kernel_x1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x2=%d  -Dydim0_advec_mom_kernel_x2=%d  -Dxdim1_advec_mom_kernel_x2=%d  -Dydim1_advec_mom_kernel_x2=%d  -Dxdim2_advec_mom_kernel_x2=%d  -Dydim2_advec_mom_kernel_x2=%d  -Dxdim3_advec_mom_kernel_x2=%d  -Dydim3_advec_mom_kernel_x2=%d  -Dxdim4_advec_mom_kernel_x2=%d  -Dydim4_advec_mom_kernel_x2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_x2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x3_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_x3_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x3(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x3.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x3.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x3(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x3=%d  -Dydim0_advec_mom_kernel_x3=%d  -Dxdim1_advec_mom_kernel_x3=%d  -Dydim1_advec_mom_kernel_x3=%d  -Dxdim2_advec_mom_kernel_x3=%d  -Dydim2_advec_mom_kernel_x3=%d  -Dxdim3_advec_mom_kernel_x3=%d  -Dydim3_advec_mom_kernel_x3=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel_x3(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_y2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_y2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_y2=%d  -Dydim0_advec_mom_kernel_y2=%d  -Dxdim1_advec_mom_kernel_y2=%d  -Dydim1_advec_mom_kernel_y2=%d  -Dxdim2_advec_mom_kernel_y2=%d  -Dydim2_advec_mom_kernel_y2=%d  -Dxdim3_advec_mom_kernel_y2=%d  -Dydim3_advec_mom_kernel_y2=%d  -Dxdim4_advec_mom_kernel_y2=%d  -Dydim4_advec_mom_kernel_y2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_y2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_z1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_z1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_z1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_z1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_z1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_z1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_z1=%d  -Dydim0_advec_mom_kernel_z1=%d  -Dxdim1_advec_mom_kernel_z1=%d  -Dydim1_advec_mom_kernel_z1=%d  -Dxdim2_advec_mom_kernel_z1=%d  -Dydim2_advec_mom_kernel_z1=%d  -Dxdim3_advec_mom_kernel_z1=%d  -Dydim3_advec_mom_kernel_z1=%d  -Dxdim4_advec_mom_kernel_z1=%d  -Dydim4_advec_mom_kernel_z1=%d  -Dxdim5_advec_mom_kernel_z1=%d  -Dydim5_advec_mom_kernel_z1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_mom_kernel_z1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_z3_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/advec_mom_kernel_z3_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_z3(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_z3.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_z3.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_z3(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_z3=%d  -Dydim0_advec_mom_kernel_z3=%d  -Dxdim1_advec_mom_kernel_z3=%d  -Dydim1_advec_mom_kernel_z3=%d  -Dxdim2_advec_mom_kernel_z3=%d  -Dydim2_advec_mom_kernel_z3=%d  -Dxdim3_advec_mom_kernel_z3=%d  -Dydim3_advec_mom_kernel_z3=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel_z3(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int ydim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_get.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_get.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int ydim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_get=%d  -Dydim0_calc_dt_kernel_get=%d  -Dxdim1_calc_dt_kernel_get=%d  -Dydim1_calc_dt_kernel_get=%d  -Dxdim4_calc_dt_kernel_get=%d  -Dydim4_calc_dt_kernel_get=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -215,9 +215,6 @@ void ops_par_loop_calc_dt_kernel_get(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0, int ydim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_min.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_min.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0, int ydim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_min=%d  -Dydim0_calc_dt_kernel_min=%d ", pPath, 32,xdim0,ydim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -184,7 +184,6 @@ void ops_par_loop_calc_dt_kernel_min(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int ydim0, int xdim1, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int ydim0, int xdim1, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel=%d  -Dydim0_calc_dt_kernel=%d  -Dxdim1_calc_dt_kernel=%d  -Dydim1_calc_dt_kernel=%d  -Dxdim2_calc_dt_kernel=%d  -Dydim2_calc_dt_kernel=%d  -Dxdim3_calc_dt_kernel=%d  -Dydim3_calc_dt_kernel=%d  -Dxdim4_calc_dt_kernel=%d  -Dydim4_calc_dt_kernel=%d  -Dxdim5_calc_dt_kernel=%d  -Dydim5_calc_dt_kernel=%d  -Dxdim6_calc_dt_kernel=%d  -Dydim6_calc_dt_kernel=%d  -Dxdim7_calc_dt_kernel=%d  -Dydim7_calc_dt_kernel=%d  -Dxdim8_calc_dt_kernel=%d  -Dydim8_calc_dt_kernel=%d  -Dxdim9_calc_dt_kernel=%d  -Dydim9_calc_dt_kernel=%d  -Dxdim10_calc_dt_kernel=%d  -Dydim10_calc_dt_kernel=%d  -Dxdim11_calc_dt_kernel=%d  -Dydim11_calc_dt_kernel=%d  -Dxdim12_calc_dt_kernel=%d  -Dydim12_calc_dt_kernel=%d  -Dxdim13_calc_dt_kernel=%d  -Dydim13_calc_dt_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_calc_dt_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_print.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_print.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_print=%d  -Dydim0_calc_dt_kernel_print=%d  -Dxdim1_calc_dt_kernel_print=%d  -Dydim1_calc_dt_kernel_print=%d  -Dxdim2_calc_dt_kernel_print=%d  -Dydim2_calc_dt_kernel_print=%d  -Dxdim3_calc_dt_kernel_print=%d  -Dydim3_calc_dt_kernel_print=%d  -Dxdim4_calc_dt_kernel_print=%d  -Dydim4_calc_dt_kernel_print=%d  -Dxdim5_calc_dt_kernel_print=%d  -Dydim5_calc_dt_kernel_print=%d  -Dxdim6_calc_dt_kernel_print=%d  -Dydim6_calc_dt_kernel_print=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -197,13 +197,6 @@ void ops_par_loop_calc_dt_kernel_print(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/field_summary_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/field_summary_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/field_summary_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/field_summary_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_field_summary_kernel=%d  -Dydim0_field_summary_kernel=%d  -Dxdim1_field_summary_kernel=%d  -Dydim1_field_summary_kernel=%d  -Dxdim2_field_summary_kernel=%d  -Dydim2_field_summary_kernel=%d  -Dxdim3_field_summary_kernel=%d  -Dydim3_field_summary_kernel=%d  -Dxdim4_field_summary_kernel=%d  -Dydim4_field_summary_kernel=%d  -Dxdim5_field_summary_kernel=%d  -Dydim5_field_summary_kernel=%d  -Dxdim6_field_summary_kernel=%d  -Dydim6_field_summary_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -250,13 +250,6 @@ void ops_par_loop_field_summary_kernel(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernelx.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernelx.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernelx=%d  -Dydim0_flux_calc_kernelx=%d  -Dxdim1_flux_calc_kernelx=%d  -Dydim1_flux_calc_kernelx=%d  -Dxdim2_flux_calc_kernelx=%d  -Dydim2_flux_calc_kernelx=%d  -Dxdim3_flux_calc_kernelx=%d  -Dydim3_flux_calc_kernelx=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernelx(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernely_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernely_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernely.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernely.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernely=%d  -Dydim0_flux_calc_kernely=%d  -Dxdim1_flux_calc_kernely=%d  -Dydim1_flux_calc_kernely=%d  -Dxdim2_flux_calc_kernely=%d  -Dydim2_flux_calc_kernely=%d  -Dxdim3_flux_calc_kernely=%d  -Dydim3_flux_calc_kernely=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernely(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernelz_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/flux_calc_kernelz_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernelz(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernelz.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernelz.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernelz(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernelz=%d  -Dydim0_flux_calc_kernelz=%d  -Dxdim1_flux_calc_kernelz=%d  -Dydim1_flux_calc_kernelz=%d  -Dxdim2_flux_calc_kernelz=%d  -Dydim2_flux_calc_kernelz=%d  -Dxdim3_flux_calc_kernelz=%d  -Dydim3_flux_calc_kernelz=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernelz(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int ydim0, int xdim1, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/ideal_gas_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/ideal_gas_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int ydim0, int xdim1, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_ideal_gas_kernel=%d  -Dydim0_ideal_gas_kernel=%d  -Dxdim1_ideal_gas_kernel=%d  -Dydim1_ideal_gas_kernel=%d  -Dxdim2_ideal_gas_kernel=%d  -Dydim2_ideal_gas_kernel=%d  -Dxdim3_ideal_gas_kernel=%d  -Dydim3_ideal_gas_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_ideal_gas_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/reset_field_kernel1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/reset_field_kernel1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel1=%d  -Dydim0_reset_field_kernel1=%d  -Dxdim1_reset_field_kernel1=%d  -Dydim1_reset_field_kernel1=%d  -Dxdim2_reset_field_kernel1=%d  -Dydim2_reset_field_kernel1=%d  -Dxdim3_reset_field_kernel1=%d  -Dydim3_reset_field_kernel1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_reset_field_kernel1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/reset_field_kernel2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/reset_field_kernel2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel2=%d  -Dydim0_reset_field_kernel2=%d  -Dxdim1_reset_field_kernel2=%d  -Dydim1_reset_field_kernel2=%d  -Dxdim2_reset_field_kernel2=%d  -Dydim2_reset_field_kernel2=%d  -Dxdim3_reset_field_kernel2=%d  -Dydim3_reset_field_kernel2=%d  -Dxdim4_reset_field_kernel2=%d  -Dydim4_reset_field_kernel2=%d  -Dxdim5_reset_field_kernel2=%d  -Dydim5_reset_field_kernel2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_reset_field_kernel2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/revert_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/revert_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int ydim0, int xdim1, int ydim1
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/revert_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/revert_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int ydim0, int xdim1, int ydim1
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_revert_kernel=%d  -Dydim0_revert_kernel=%d  -Dxdim1_revert_kernel=%d  -Dydim1_revert_kernel=%d  -Dxdim2_revert_kernel=%d  -Dydim2_revert_kernel=%d  -Dxdim3_revert_kernel=%d  -Dydim3_revert_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_revert_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b1=%d  -Dydim0_update_halo_kernel1_b1=%d  -Dxdim1_update_halo_kernel1_b1=%d  -Dydim1_update_halo_kernel1_b1=%d  -Dxdim2_update_halo_kernel1_b1=%d  -Dydim2_update_halo_kernel1_b1=%d  -Dxdim3_update_halo_kernel1_b1=%d  -Dydim3_update_halo_kernel1_b1=%d  -Dxdim4_update_halo_kernel1_b1=%d  -Dydim4_update_halo_kernel1_b1=%d  -Dxdim5_update_halo_kernel1_b1=%d  -Dydim5_update_halo_kernel1_b1=%d  -Dxdim6_update_halo_kernel1_b1=%d  -Dydim6_update_halo_kernel1_b1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_b1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b2=%d  -Dydim0_update_halo_kernel1_b2=%d  -Dxdim1_update_halo_kernel1_b2=%d  -Dydim1_update_halo_kernel1_b2=%d  -Dxdim2_update_halo_kernel1_b2=%d  -Dydim2_update_halo_kernel1_b2=%d  -Dxdim3_update_halo_kernel1_b2=%d  -Dydim3_update_halo_kernel1_b2=%d  -Dxdim4_update_halo_kernel1_b2=%d  -Dydim4_update_halo_kernel1_b2=%d  -Dxdim5_update_halo_kernel1_b2=%d  -Dydim5_update_halo_kernel1_b2=%d  -Dxdim6_update_halo_kernel1_b2=%d  -Dydim6_update_halo_kernel1_b2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_b2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_ba1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_ba1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba1(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_ba1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_ba1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba1(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_ba1=%d  -Dydim0_update_halo_kernel1_ba1=%d  -Dxdim1_update_halo_kernel1_ba1=%d  -Dydim1_update_halo_kernel1_ba1=%d  -Dxdim2_update_halo_kernel1_ba1=%d  -Dydim2_update_halo_kernel1_ba1=%d  -Dxdim3_update_halo_kernel1_ba1=%d  -Dydim3_update_halo_kernel1_ba1=%d  -Dxdim4_update_halo_kernel1_ba1=%d  -Dydim4_update_halo_kernel1_ba1=%d  -Dxdim5_update_halo_kernel1_ba1=%d  -Dydim5_update_halo_kernel1_ba1=%d  -Dxdim6_update_halo_kernel1_ba1=%d  -Dydim6_update_halo_kernel1_ba1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_ba1(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_ba2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_ba2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba2(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_ba2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_ba2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba2(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_ba2=%d  -Dydim0_update_halo_kernel1_ba2=%d  -Dxdim1_update_halo_kernel1_ba2=%d  -Dydim1_update_halo_kernel1_ba2=%d  -Dxdim2_update_halo_kernel1_ba2=%d  -Dydim2_update_halo_kernel1_ba2=%d  -Dxdim3_update_halo_kernel1_ba2=%d  -Dydim3_update_halo_kernel1_ba2=%d  -Dxdim4_update_halo_kernel1_ba2=%d  -Dydim4_update_halo_kernel1_ba2=%d  -Dxdim5_update_halo_kernel1_ba2=%d  -Dydim5_update_halo_kernel1_ba2=%d  -Dxdim6_update_halo_kernel1_ba2=%d  -Dydim6_update_halo_kernel1_ba2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_ba2(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_fr1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_fr1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr1(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_fr1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_fr1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr1(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_fr1=%d  -Dydim0_update_halo_kernel1_fr1=%d  -Dxdim1_update_halo_kernel1_fr1=%d  -Dydim1_update_halo_kernel1_fr1=%d  -Dxdim2_update_halo_kernel1_fr1=%d  -Dydim2_update_halo_kernel1_fr1=%d  -Dxdim3_update_halo_kernel1_fr1=%d  -Dydim3_update_halo_kernel1_fr1=%d  -Dxdim4_update_halo_kernel1_fr1=%d  -Dydim4_update_halo_kernel1_fr1=%d  -Dxdim5_update_halo_kernel1_fr1=%d  -Dydim5_update_halo_kernel1_fr1=%d  -Dxdim6_update_halo_kernel1_fr1=%d  -Dydim6_update_halo_kernel1_fr1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_fr1(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_fr2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_fr2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr2(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_fr2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_fr2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr2(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_fr2=%d  -Dydim0_update_halo_kernel1_fr2=%d  -Dxdim1_update_halo_kernel1_fr2=%d  -Dydim1_update_halo_kernel1_fr2=%d  -Dxdim2_update_halo_kernel1_fr2=%d  -Dydim2_update_halo_kernel1_fr2=%d  -Dxdim3_update_halo_kernel1_fr2=%d  -Dydim3_update_halo_kernel1_fr2=%d  -Dxdim4_update_halo_kernel1_fr2=%d  -Dydim4_update_halo_kernel1_fr2=%d  -Dxdim5_update_halo_kernel1_fr2=%d  -Dydim5_update_halo_kernel1_fr2=%d  -Dxdim6_update_halo_kernel1_fr2=%d  -Dydim6_update_halo_kernel1_fr2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_fr2(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l1=%d  -Dydim0_update_halo_kernel1_l1=%d  -Dxdim1_update_halo_kernel1_l1=%d  -Dydim1_update_halo_kernel1_l1=%d  -Dxdim2_update_halo_kernel1_l1=%d  -Dydim2_update_halo_kernel1_l1=%d  -Dxdim3_update_halo_kernel1_l1=%d  -Dydim3_update_halo_kernel1_l1=%d  -Dxdim4_update_halo_kernel1_l1=%d  -Dydim4_update_halo_kernel1_l1=%d  -Dxdim5_update_halo_kernel1_l1=%d  -Dydim5_update_halo_kernel1_l1=%d  -Dxdim6_update_halo_kernel1_l1=%d  -Dydim6_update_halo_kernel1_l1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_l1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l2=%d  -Dydim0_update_halo_kernel1_l2=%d  -Dxdim1_update_halo_kernel1_l2=%d  -Dydim1_update_halo_kernel1_l2=%d  -Dxdim2_update_halo_kernel1_l2=%d  -Dydim2_update_halo_kernel1_l2=%d  -Dxdim3_update_halo_kernel1_l2=%d  -Dydim3_update_halo_kernel1_l2=%d  -Dxdim4_update_halo_kernel1_l2=%d  -Dydim4_update_halo_kernel1_l2=%d  -Dxdim5_update_halo_kernel1_l2=%d  -Dydim5_update_halo_kernel1_l2=%d  -Dxdim6_update_halo_kernel1_l2=%d  -Dydim6_update_halo_kernel1_l2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_l2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r1=%d  -Dydim0_update_halo_kernel1_r1=%d  -Dxdim1_update_halo_kernel1_r1=%d  -Dydim1_update_halo_kernel1_r1=%d  -Dxdim2_update_halo_kernel1_r1=%d  -Dydim2_update_halo_kernel1_r1=%d  -Dxdim3_update_halo_kernel1_r1=%d  -Dydim3_update_halo_kernel1_r1=%d  -Dxdim4_update_halo_kernel1_r1=%d  -Dydim4_update_halo_kernel1_r1=%d  -Dxdim5_update_halo_kernel1_r1=%d  -Dydim5_update_halo_kernel1_r1=%d  -Dxdim6_update_halo_kernel1_r1=%d  -Dydim6_update_halo_kernel1_r1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_r1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r2=%d  -Dydim0_update_halo_kernel1_r2=%d  -Dxdim1_update_halo_kernel1_r2=%d  -Dydim1_update_halo_kernel1_r2=%d  -Dxdim2_update_halo_kernel1_r2=%d  -Dydim2_update_halo_kernel1_r2=%d  -Dxdim3_update_halo_kernel1_r2=%d  -Dydim3_update_halo_kernel1_r2=%d  -Dxdim4_update_halo_kernel1_r2=%d  -Dydim4_update_halo_kernel1_r2=%d  -Dxdim5_update_halo_kernel1_r2=%d  -Dydim5_update_halo_kernel1_r2=%d  -Dxdim6_update_halo_kernel1_r2=%d  -Dydim6_update_halo_kernel1_r2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_r2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t1=%d  -Dydim0_update_halo_kernel1_t1=%d  -Dxdim1_update_halo_kernel1_t1=%d  -Dydim1_update_halo_kernel1_t1=%d  -Dxdim2_update_halo_kernel1_t1=%d  -Dydim2_update_halo_kernel1_t1=%d  -Dxdim3_update_halo_kernel1_t1=%d  -Dydim3_update_halo_kernel1_t1=%d  -Dxdim4_update_halo_kernel1_t1=%d  -Dydim4_update_halo_kernel1_t1=%d  -Dxdim5_update_halo_kernel1_t1=%d  -Dydim5_update_halo_kernel1_t1=%d  -Dxdim6_update_halo_kernel1_t1=%d  -Dydim6_update_halo_kernel1_t1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_t1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t2=%d  -Dydim0_update_halo_kernel1_t2=%d  -Dxdim1_update_halo_kernel1_t2=%d  -Dydim1_update_halo_kernel1_t2=%d  -Dxdim2_update_halo_kernel1_t2=%d  -Dydim2_update_halo_kernel1_t2=%d  -Dxdim3_update_halo_kernel1_t2=%d  -Dydim3_update_halo_kernel1_t2=%d  -Dxdim4_update_halo_kernel1_t2=%d  -Dydim4_update_halo_kernel1_t2=%d  -Dxdim5_update_halo_kernel1_t2=%d  -Dydim5_update_halo_kernel1_t2=%d  -Dxdim6_update_halo_kernel1_t2=%d  -Dydim6_update_halo_kernel1_t2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_t2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_left(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_left(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_left=%d  -Dydim0_update_halo_kernel2_xvel_minus_2_left=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_left=%d  -Dydim1_update_halo_kernel2_xvel_minus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_left(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_right(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_right(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_right=%d  -Dydim0_update_halo_kernel2_xvel_minus_2_right=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_right=%d  -Dydim1_update_halo_kernel2_xvel_minus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_right(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_left(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_left(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_left=%d  -Dydim0_update_halo_kernel2_xvel_minus_4_left=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_left=%d  -Dydim1_update_halo_kernel2_xvel_minus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_left(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_minus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_right(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_right(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_right=%d  -Dydim0_update_halo_kernel2_xvel_minus_4_right=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_right=%d  -Dydim1_update_halo_kernel2_xvel_minus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_right(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_back=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_back=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_back=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_bot=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_bot=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_bot=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_front=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_front=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_front=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_top=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_top=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_top=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_back=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_back=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_back=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_bot=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_bot=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_bot=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_front=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_front=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_front=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_xvel_plus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_top=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_top=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_top=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_bot(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_bot(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_bot=%d  -Dydim0_update_halo_kernel2_yvel_minus_2_bot=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_bot=%d  -Dydim1_update_halo_kernel2_yvel_minus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_bot(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_top(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_top(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_top=%d  -Dydim0_update_halo_kernel2_yvel_minus_2_top=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_top=%d  -Dydim1_update_halo_kernel2_yvel_minus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_top(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_bot(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_bot(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_bot=%d  -Dydim0_update_halo_kernel2_yvel_minus_4_bot=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_bot=%d  -Dydim1_update_halo_kernel2_yvel_minus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_bot(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_minus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_top(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_top(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_top=%d  -Dydim0_update_halo_kernel2_yvel_minus_4_top=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_top=%d  -Dydim1_update_halo_kernel2_yvel_minus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_top(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_back=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_back=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_back=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_front=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_front=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_front=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_left=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_left=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_left=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_right=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_right=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_right=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_back=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_back=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_back=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_front=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_front=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_front=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_left=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_left=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_left=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_yvel_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_right=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_right=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_right=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_back(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_back(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_2_back=%d  -Dydim0_update_halo_kernel2_zvel_minus_2_back=%d  -Dxdim1_update_halo_kernel2_zvel_minus_2_back=%d  -Dydim1_update_halo_kernel2_zvel_minus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_2_back(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_front(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_front(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_2_front=%d  -Dydim0_update_halo_kernel2_zvel_minus_2_front=%d  -Dxdim1_update_halo_kernel2_zvel_minus_2_front=%d  -Dydim1_update_halo_kernel2_zvel_minus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_2_front(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_back(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_back(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_4_back=%d  -Dydim0_update_halo_kernel2_zvel_minus_4_back=%d  -Dxdim1_update_halo_kernel2_zvel_minus_4_back=%d  -Dydim1_update_halo_kernel2_zvel_minus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_4_back(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_minus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_front(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_front(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_4_front=%d  -Dydim0_update_halo_kernel2_zvel_minus_4_front=%d  -Dxdim1_update_halo_kernel2_zvel_minus_4_front=%d  -Dydim1_update_halo_kernel2_zvel_minus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_4_front(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_bot=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_bot=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_bot=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_left=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_left=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_left=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_right=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_right=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_right=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_top=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_top=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_top=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_bot=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_bot=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_bot=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_left=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_left=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_left=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_right=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_right=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_right=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel2_zvel_plus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_top=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_top=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_top=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_a=%d  -Dydim0_update_halo_kernel3_minus_2_a=%d  -Dxdim1_update_halo_kernel3_minus_2_a=%d  -Dydim1_update_halo_kernel3_minus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_b=%d  -Dydim0_update_halo_kernel3_minus_2_b=%d  -Dxdim1_update_halo_kernel3_minus_2_b=%d  -Dydim1_update_halo_kernel3_minus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_a=%d  -Dydim0_update_halo_kernel3_minus_4_a=%d  -Dxdim1_update_halo_kernel3_minus_4_a=%d  -Dydim1_update_halo_kernel3_minus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_b=%d  -Dydim0_update_halo_kernel3_minus_4_b=%d  -Dxdim1_update_halo_kernel3_minus_4_b=%d  -Dydim1_update_halo_kernel3_minus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_a=%d  -Dydim0_update_halo_kernel3_plus_2_a=%d  -Dxdim1_update_halo_kernel3_plus_2_a=%d  -Dydim1_update_halo_kernel3_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_b=%d  -Dydim0_update_halo_kernel3_plus_2_b=%d  -Dxdim1_update_halo_kernel3_plus_2_b=%d  -Dydim1_update_halo_kernel3_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_back=%d  -Dydim0_update_halo_kernel3_plus_2_back=%d  -Dxdim1_update_halo_kernel3_plus_2_back=%d  -Dydim1_update_halo_kernel3_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_front=%d  -Dydim0_update_halo_kernel3_plus_2_front=%d  -Dxdim1_update_halo_kernel3_plus_2_front=%d  -Dydim1_update_halo_kernel3_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_a=%d  -Dydim0_update_halo_kernel3_plus_4_a=%d  -Dxdim1_update_halo_kernel3_plus_4_a=%d  -Dydim1_update_halo_kernel3_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_b=%d  -Dydim0_update_halo_kernel3_plus_4_b=%d  -Dxdim1_update_halo_kernel3_plus_4_b=%d  -Dydim1_update_halo_kernel3_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_back=%d  -Dydim0_update_halo_kernel3_plus_4_back=%d  -Dxdim1_update_halo_kernel3_plus_4_back=%d  -Dydim1_update_halo_kernel3_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel3_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_front=%d  -Dydim0_update_halo_kernel3_plus_4_front=%d  -Dxdim1_update_halo_kernel3_plus_4_front=%d  -Dydim1_update_halo_kernel3_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_a=%d  -Dydim0_update_halo_kernel4_minus_2_a=%d  -Dxdim1_update_halo_kernel4_minus_2_a=%d  -Dydim1_update_halo_kernel4_minus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_b=%d  -Dydim0_update_halo_kernel4_minus_2_b=%d  -Dxdim1_update_halo_kernel4_minus_2_b=%d  -Dydim1_update_halo_kernel4_minus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_a=%d  -Dydim0_update_halo_kernel4_minus_4_a=%d  -Dxdim1_update_halo_kernel4_minus_4_a=%d  -Dydim1_update_halo_kernel4_minus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_b=%d  -Dydim0_update_halo_kernel4_minus_4_b=%d  -Dxdim1_update_halo_kernel4_minus_4_b=%d  -Dydim1_update_halo_kernel4_minus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_a=%d  -Dydim0_update_halo_kernel4_plus_2_a=%d  -Dxdim1_update_halo_kernel4_plus_2_a=%d  -Dydim1_update_halo_kernel4_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_b=%d  -Dydim0_update_halo_kernel4_plus_2_b=%d  -Dxdim1_update_halo_kernel4_plus_2_b=%d  -Dydim1_update_halo_kernel4_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_back=%d  -Dydim0_update_halo_kernel4_plus_2_back=%d  -Dxdim1_update_halo_kernel4_plus_2_back=%d  -Dydim1_update_halo_kernel4_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_front=%d  -Dydim0_update_halo_kernel4_plus_2_front=%d  -Dxdim1_update_halo_kernel4_plus_2_front=%d  -Dydim1_update_halo_kernel4_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_a=%d  -Dydim0_update_halo_kernel4_plus_4_a=%d  -Dxdim1_update_halo_kernel4_plus_4_a=%d  -Dydim1_update_halo_kernel4_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_b=%d  -Dydim0_update_halo_kernel4_plus_4_b=%d  -Dxdim1_update_halo_kernel4_plus_4_b=%d  -Dydim1_update_halo_kernel4_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_back=%d  -Dydim0_update_halo_kernel4_plus_4_back=%d  -Dxdim1_update_halo_kernel4_plus_4_back=%d  -Dydim1_update_halo_kernel4_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel4_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_front=%d  -Dydim0_update_halo_kernel4_plus_4_front=%d  -Dxdim1_update_halo_kernel4_plus_4_front=%d  -Dydim1_update_halo_kernel4_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_back(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_back(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_2_back=%d  -Dydim0_update_halo_kernel5_minus_2_back=%d  -Dxdim1_update_halo_kernel5_minus_2_back=%d  -Dydim1_update_halo_kernel5_minus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_2_back(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_front(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_front(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_2_front=%d  -Dydim0_update_halo_kernel5_minus_2_front=%d  -Dxdim1_update_halo_kernel5_minus_2_front=%d  -Dydim1_update_halo_kernel5_minus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_2_front(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_back(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_back(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_4_back=%d  -Dydim0_update_halo_kernel5_minus_4_back=%d  -Dxdim1_update_halo_kernel5_minus_4_back=%d  -Dydim1_update_halo_kernel5_minus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_4_back(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_minus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_front(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_front(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_4_front=%d  -Dydim0_update_halo_kernel5_minus_4_front=%d  -Dxdim1_update_halo_kernel5_minus_4_front=%d  -Dydim1_update_halo_kernel5_minus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_4_front(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_a=%d  -Dydim0_update_halo_kernel5_plus_2_a=%d  -Dxdim1_update_halo_kernel5_plus_2_a=%d  -Dydim1_update_halo_kernel5_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_b=%d  -Dydim0_update_halo_kernel5_plus_2_b=%d  -Dxdim1_update_halo_kernel5_plus_2_b=%d  -Dydim1_update_halo_kernel5_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_left(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_left(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_left=%d  -Dydim0_update_halo_kernel5_plus_2_left=%d  -Dxdim1_update_halo_kernel5_plus_2_left=%d  -Dydim1_update_halo_kernel5_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_left(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_right(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_right(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_right=%d  -Dydim0_update_halo_kernel5_plus_2_right=%d  -Dxdim1_update_halo_kernel5_plus_2_right=%d  -Dydim1_update_halo_kernel5_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_right(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_a=%d  -Dydim0_update_halo_kernel5_plus_4_a=%d  -Dxdim1_update_halo_kernel5_plus_4_a=%d  -Dydim1_update_halo_kernel5_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_b=%d  -Dydim0_update_halo_kernel5_plus_4_b=%d  -Dxdim1_update_halo_kernel5_plus_4_b=%d  -Dydim1_update_halo_kernel5_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_left(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_left(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_left=%d  -Dydim0_update_halo_kernel5_plus_4_left=%d  -Dxdim1_update_halo_kernel5_plus_4_left=%d  -Dydim1_update_halo_kernel5_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_left(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/update_halo_kernel5_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_right(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_right(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_right=%d  -Dydim0_update_halo_kernel5_plus_4_right=%d  -Dxdim1_update_halo_kernel5_plus_4_right=%d  -Dydim1_update_halo_kernel5_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_right(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/OpenCL/viscosity_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenCL/viscosity_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int ydim0, int xdim1, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/viscosity_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/viscosity_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int ydim0, int xdim1, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_viscosity_kernel=%d  -Dydim0_viscosity_kernel=%d  -Dxdim1_viscosity_kernel=%d  -Dydim1_viscosity_kernel=%d  -Dxdim2_viscosity_kernel=%d  -Dydim2_viscosity_kernel=%d  -Dxdim3_viscosity_kernel=%d  -Dydim3_viscosity_kernel=%d  -Dxdim4_viscosity_kernel=%d  -Dydim4_viscosity_kernel=%d  -Dxdim5_viscosity_kernel=%d  -Dydim5_viscosity_kernel=%d  -Dxdim6_viscosity_kernel=%d  -Dydim6_viscosity_kernel=%d  -Dxdim7_viscosity_kernel=%d  -Dydim7_viscosity_kernel=%d  -Dxdim8_viscosity_kernel=%d  -Dydim8_viscosity_kernel=%d  -Dxdim9_viscosity_kernel=%d  -Dydim9_viscosity_kernel=%d  -Dxdim10_viscosity_kernel=%d  -Dydim10_viscosity_kernel=%d  -Dxdim11_viscosity_kernel=%d  -Dydim11_viscosity_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,18 +187,6 @@ void ops_par_loop_viscosity_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D/advec_mom.cpp
+++ b/apps/c/CloverLeaf_3D/advec_mom.cpp
@@ -40,8 +40,7 @@
 void advec_mom(int which_vel, int sweep_number, int dir)
 {
   //initialize sizes using global values
-  int x_cells = grid.x_cells;
-  int y_cells = grid.y_cells;
+
   int x_min = field.x_min;
   int x_max = field.x_max;
   int y_min = field.y_min;
@@ -50,8 +49,6 @@ void advec_mom(int which_vel, int sweep_number, int dir)
   int z_max = field.z_max;
 
   int rangexyz[] = {x_min-2,x_max+2,y_min-2,y_max+2,z_min-2,z_max+2}; // full range over grid
-
-  int mom_sweep;
   ops_dat vel1;
 
   if( which_vel == 1) {
@@ -112,12 +109,6 @@ void advec_mom(int which_vel, int sweep_number, int dir)
         ops_arg_dat(volume, 1, S3D_000, "double", OPS_READ),
         ops_arg_dat(vol_flux_z, 1, S3D_000_00P1, "double", OPS_READ));
   }
-
-
-  int range_partx_party_1[] = {x_min-1,x_max+2,y_min,y_max+1}; // partial x range partial y range
-
-  int range_fully_party_1[] = {x_min,x_max+1,y_min-2,y_max+2}; // full y range partial x range
-  int range_partx_party_2[] = {x_min,x_max+1,y_min-1,y_max+2}; // partial x range partial y range
 
   if (dir == 1) {
     if (which_vel == 1) {

--- a/apps/c/CloverLeaf_3D/advec_mom_ops.cpp
+++ b/apps/c/CloverLeaf_3D/advec_mom_ops.cpp
@@ -138,8 +138,7 @@ void ops_par_loop_advec_mom_kernel2_z(char const *, ops_block, int , int*,
 void advec_mom(int which_vel, int sweep_number, int dir)
 {
 
-  int x_cells = grid.x_cells;
-  int y_cells = grid.y_cells;
+
   int x_min = field.x_min;
   int x_max = field.x_max;
   int y_min = field.y_min;
@@ -148,8 +147,6 @@ void advec_mom(int which_vel, int sweep_number, int dir)
   int z_max = field.z_max;
 
   int rangexyz[] = {x_min-2,x_max+2,y_min-2,y_max+2,z_min-2,z_max+2};
-
-  int mom_sweep;
   ops_dat vel1;
 
   if( which_vel == 1) {
@@ -210,11 +207,6 @@ void advec_mom(int which_vel, int sweep_number, int dir)
                  ops_arg_dat(volume, 1, S3D_000, "double", OPS_READ),
                  ops_arg_dat(vol_flux_z, 1, S3D_000_00P1, "double", OPS_READ));
   }
-
-  int range_partx_party_1[] = {x_min-1,x_max+2,y_min,y_max+1};
-
-  int range_fully_party_1[] = {x_min,x_max+1,y_min-2,y_max+2};
-  int range_partx_party_2[] = {x_min,x_max+1,y_min-1,y_max+2};
 
   if (dir == 1) {
     if (which_vel == 1) {

--- a/apps/c/CloverLeaf_3D/clover_bm.in
+++ b/apps/c/CloverLeaf_3D/clover_bm.in
@@ -3,7 +3,7 @@
  state 1 density=0.2 energy=1.0
  state 2 density=1.0 energy=2.5 geometry=cuboid xmin=0.0 xmax=5.0 ymin=0.0 ymax=2.0 zmin=0.0 zmax=4.0
 
- x_cells=192
+ x_cells=96
  y_cells=96
  z_cells=96
 

--- a/apps/c/CloverLeaf_3D/clover_bm.in
+++ b/apps/c/CloverLeaf_3D/clover_bm.in
@@ -3,7 +3,7 @@
  state 1 density=0.2 energy=1.0
  state 2 density=1.0 energy=2.5 geometry=cuboid xmin=0.0 xmax=5.0 ymin=0.0 ymax=2.0 zmin=0.0 zmax=4.0
 
- x_cells=96
+ x_cells=192
  y_cells=96
  z_cells=96
 

--- a/apps/c/CloverLeaf_3D/data.h
+++ b/apps/c/CloverLeaf_3D/data.h
@@ -203,5 +203,4 @@ extern ops_reduction red_ie;
 extern ops_reduction red_ke;
 extern ops_reduction red_press;
 extern ops_reduction red_output;
-
-#endif /* #ifndef __CLOVER_LEAF_DATA_H*/
+#endif

--- a/apps/c/CloverLeaf_3D/flux_calc.cpp
+++ b/apps/c/CloverLeaf_3D/flux_calc.cpp
@@ -40,8 +40,6 @@ void flux_calc()
   error_condition = 0; // Not used yet due to issue with OpenA reduction
 
   //initialize sizes using global values
-  int x_cells = grid.x_cells;
-  int y_cells = grid.y_cells;
   int x_min = field.x_min;
   int x_max = field.x_max;
   int y_min = field.y_min;

--- a/apps/c/CloverLeaf_3D/flux_calc_ops.cpp
+++ b/apps/c/CloverLeaf_3D/flux_calc_ops.cpp
@@ -44,8 +44,6 @@ void flux_calc()
 {
   error_condition = 0;
 
-  int x_cells = grid.x_cells;
-  int y_cells = grid.y_cells;
   int x_min = field.x_min;
   int x_max = field.x_max;
   int y_min = field.y_min;

--- a/apps/c/CloverLeaf_3D/test.sh
+++ b/apps/c/CloverLeaf_3D/test.sh
@@ -74,7 +74,7 @@ grep "step:   2955" clover.out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -147,7 +147,7 @@ grep "step:   2955" clover.out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make cuda
 make mpi_cuda
 cd -

--- a/apps/c/CloverLeaf_3D/user_types.h
+++ b/apps/c/CloverLeaf_3D/user_types.h
@@ -68,5 +68,4 @@ inline int type_error (const state_type * a, const char *type ) {
   (void)a; return (strcmp ( type, "state_type" ) && strcmp ( type, "state_type:soa" ));
 }
 #endif
-
 #endif

--- a/apps/c/CloverLeaf_3D_HDF5/MPI/generate_chunk_kernel_seq_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/MPI/generate_chunk_kernel_seq_kernel.cpp
@@ -562,16 +562,16 @@ void ops_par_loop_generate_chunk_kernel(char const *name, ops_block block, int d
     //Update kernel record
     ops_timers_core(&c1,&t1);
     OPS_kernels[56].mpi_time += t1-t2;
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg0);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg1);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg2);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg3);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg4);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg5);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg6);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg7);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg8);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg9);
-    OPS_kernels[56].transfer += ops_compute_transfer(dim, range, &arg10);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg0);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg1);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg2);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg3);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg4);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg5);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg6);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg7);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg8);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg9);
+    OPS_kernels[56].transfer += ops_compute_transfer(dim, start, end, &arg10);
   }
 }

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/PdV_kernel_nopredict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_nopredict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_nopredict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_nopredict(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_nopredict=%d  -Dydim0_PdV_kernel_nopredict=%d  -Dxdim1_PdV_kernel_nopredict=%d  -Dydim1_PdV_kernel_nopredict=%d  -Dxdim2_PdV_kernel_nopredict=%d  -Dydim2_PdV_kernel_nopredict=%d  -Dxdim3_PdV_kernel_nopredict=%d  -Dydim3_PdV_kernel_nopredict=%d  -Dxdim4_PdV_kernel_nopredict=%d  -Dydim4_PdV_kernel_nopredict=%d  -Dxdim5_PdV_kernel_nopredict=%d  -Dydim5_PdV_kernel_nopredict=%d  -Dxdim6_PdV_kernel_nopredict=%d  -Dydim6_PdV_kernel_nopredict=%d  -Dxdim7_PdV_kernel_nopredict=%d  -Dydim7_PdV_kernel_nopredict=%d  -Dxdim8_PdV_kernel_nopredict=%d  -Dydim8_PdV_kernel_nopredict=%d  -Dxdim9_PdV_kernel_nopredict=%d  -Dydim9_PdV_kernel_nopredict=%d  -Dxdim10_PdV_kernel_nopredict=%d  -Dydim10_PdV_kernel_nopredict=%d  -Dxdim11_PdV_kernel_nopredict=%d  -Dydim11_PdV_kernel_nopredict=%d  -Dxdim12_PdV_kernel_nopredict=%d  -Dydim12_PdV_kernel_nopredict=%d  -Dxdim13_PdV_kernel_nopredict=%d  -Dydim13_PdV_kernel_nopredict=%d  -Dxdim14_PdV_kernel_nopredict=%d  -Dydim14_PdV_kernel_nopredict=%d  -Dxdim15_PdV_kernel_nopredict=%d  -Dydim15_PdV_kernel_nopredict=%d  -Dxdim16_PdV_kernel_nopredict=%d  -Dydim16_PdV_kernel_nopredict=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13,xdim14,ydim14,xdim15,ydim15,xdim16,ydim16);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -198,23 +198,6 @@ void ops_par_loop_PdV_kernel_nopredict(char const *name, ops_block block, int di
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
-  int dat14 = args[14].dat->elem_size;
-  int dat15 = args[15].dat->elem_size;
-  int dat16 = args[16].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/PdV_kernel_predict_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int ydim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/PdV_kernel_predict.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/PdV_kernel_predict.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_PdV_kernel_predict(int xdim0, int ydim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_PdV_kernel_predict=%d  -Dydim0_PdV_kernel_predict=%d  -Dxdim1_PdV_kernel_predict=%d  -Dydim1_PdV_kernel_predict=%d  -Dxdim2_PdV_kernel_predict=%d  -Dydim2_PdV_kernel_predict=%d  -Dxdim3_PdV_kernel_predict=%d  -Dydim3_PdV_kernel_predict=%d  -Dxdim4_PdV_kernel_predict=%d  -Dydim4_PdV_kernel_predict=%d  -Dxdim5_PdV_kernel_predict=%d  -Dydim5_PdV_kernel_predict=%d  -Dxdim6_PdV_kernel_predict=%d  -Dydim6_PdV_kernel_predict=%d  -Dxdim7_PdV_kernel_predict=%d  -Dydim7_PdV_kernel_predict=%d  -Dxdim8_PdV_kernel_predict=%d  -Dydim8_PdV_kernel_predict=%d  -Dxdim9_PdV_kernel_predict=%d  -Dydim9_PdV_kernel_predict=%d  -Dxdim10_PdV_kernel_predict=%d  -Dydim10_PdV_kernel_predict=%d  -Dxdim11_PdV_kernel_predict=%d  -Dydim11_PdV_kernel_predict=%d  -Dxdim12_PdV_kernel_predict=%d  -Dydim12_PdV_kernel_predict=%d  -Dxdim13_PdV_kernel_predict=%d  -Dydim13_PdV_kernel_predict=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_PdV_kernel_predict(char const *name, ops_block block, int dim,
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/accelerate_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/accelerate_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/accelerate_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/accelerate_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_accelerate_kernel(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_accelerate_kernel=%d  -Dydim0_accelerate_kernel=%d  -Dxdim1_accelerate_kernel=%d  -Dydim1_accelerate_kernel=%d  -Dxdim2_accelerate_kernel=%d  -Dydim2_accelerate_kernel=%d  -Dxdim3_accelerate_kernel=%d  -Dydim3_accelerate_kernel=%d  -Dxdim4_accelerate_kernel=%d  -Dydim4_accelerate_kernel=%d  -Dxdim5_accelerate_kernel=%d  -Dydim5_accelerate_kernel=%d  -Dxdim6_accelerate_kernel=%d  -Dydim6_accelerate_kernel=%d  -Dxdim7_accelerate_kernel=%d  -Dydim7_accelerate_kernel=%d  -Dxdim8_accelerate_kernel=%d  -Dydim8_accelerate_kernel=%d  -Dxdim9_accelerate_kernel=%d  -Dydim9_accelerate_kernel=%d  -Dxdim10_accelerate_kernel=%d  -Dydim10_accelerate_kernel=%d  -Dxdim11_accelerate_kernel=%d  -Dydim11_accelerate_kernel=%d  -Dxdim12_accelerate_kernel=%d  -Dydim12_accelerate_kernel=%d  -Dxdim13_accelerate_kernel=%d  -Dydim13_accelerate_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_accelerate_kernel(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_xdir=%d  -Dydim0_advec_cell_kernel1_xdir=%d  -Dxdim1_advec_cell_kernel1_xdir=%d  -Dydim1_advec_cell_kernel1_xdir=%d  -Dxdim2_advec_cell_kernel1_xdir=%d  -Dydim2_advec_cell_kernel1_xdir=%d  -Dxdim3_advec_cell_kernel1_xdir=%d  -Dydim3_advec_cell_kernel1_xdir=%d  -Dxdim4_advec_cell_kernel1_xdir=%d  -Dydim4_advec_cell_kernel1_xdir=%d  -Dxdim5_advec_cell_kernel1_xdir=%d  -Dydim5_advec_cell_kernel1_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_cell_kernel1_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_ydir=%d  -Dydim0_advec_cell_kernel1_ydir=%d  -Dxdim1_advec_cell_kernel1_ydir=%d  -Dydim1_advec_cell_kernel1_ydir=%d  -Dxdim2_advec_cell_kernel1_ydir=%d  -Dydim2_advec_cell_kernel1_ydir=%d  -Dxdim3_advec_cell_kernel1_ydir=%d  -Dydim3_advec_cell_kernel1_ydir=%d  -Dxdim4_advec_cell_kernel1_ydir=%d  -Dydim4_advec_cell_kernel1_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_cell_kernel1_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel1_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel1_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel1_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel1_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel1_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel1_zdir=%d  -Dydim0_advec_cell_kernel1_zdir=%d  -Dxdim1_advec_cell_kernel1_zdir=%d  -Dydim1_advec_cell_kernel1_zdir=%d  -Dxdim2_advec_cell_kernel1_zdir=%d  -Dydim2_advec_cell_kernel1_zdir=%d  -Dxdim3_advec_cell_kernel1_zdir=%d  -Dydim3_advec_cell_kernel1_zdir=%d  -Dxdim4_advec_cell_kernel1_zdir=%d  -Dydim4_advec_cell_kernel1_zdir=%d  -Dxdim5_advec_cell_kernel1_zdir=%d  -Dydim5_advec_cell_kernel1_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_cell_kernel1_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_xdir=%d  -Dydim0_advec_cell_kernel2_xdir=%d  -Dxdim1_advec_cell_kernel2_xdir=%d  -Dydim1_advec_cell_kernel2_xdir=%d  -Dxdim2_advec_cell_kernel2_xdir=%d  -Dydim2_advec_cell_kernel2_xdir=%d  -Dxdim3_advec_cell_kernel2_xdir=%d  -Dydim3_advec_cell_kernel2_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_cell_kernel2_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_ydir=%d  -Dydim0_advec_cell_kernel2_ydir=%d  -Dxdim1_advec_cell_kernel2_ydir=%d  -Dydim1_advec_cell_kernel2_ydir=%d  -Dxdim2_advec_cell_kernel2_ydir=%d  -Dydim2_advec_cell_kernel2_ydir=%d  -Dxdim3_advec_cell_kernel2_ydir=%d  -Dydim3_advec_cell_kernel2_ydir=%d  -Dxdim4_advec_cell_kernel2_ydir=%d  -Dydim4_advec_cell_kernel2_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_cell_kernel2_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel2_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel2_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel2_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel2_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel2_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel2_zdir=%d  -Dydim0_advec_cell_kernel2_zdir=%d  -Dxdim1_advec_cell_kernel2_zdir=%d  -Dydim1_advec_cell_kernel2_zdir=%d  -Dxdim2_advec_cell_kernel2_zdir=%d  -Dydim2_advec_cell_kernel2_zdir=%d  -Dxdim3_advec_cell_kernel2_zdir=%d  -Dydim3_advec_cell_kernel2_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_cell_kernel2_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_xdir=%d  -Dydim0_advec_cell_kernel3_xdir=%d  -Dxdim1_advec_cell_kernel3_xdir=%d  -Dydim1_advec_cell_kernel3_xdir=%d  -Dxdim2_advec_cell_kernel3_xdir=%d  -Dydim2_advec_cell_kernel3_xdir=%d  -Dxdim3_advec_cell_kernel3_xdir=%d  -Dydim3_advec_cell_kernel3_xdir=%d  -Dxdim4_advec_cell_kernel3_xdir=%d  -Dydim4_advec_cell_kernel3_xdir=%d  -Dxdim5_advec_cell_kernel3_xdir=%d  -Dydim5_advec_cell_kernel3_xdir=%d  -Dxdim6_advec_cell_kernel3_xdir=%d  -Dydim6_advec_cell_kernel3_xdir=%d  -Dxdim7_advec_cell_kernel3_xdir=%d  -Dydim7_advec_cell_kernel3_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_ydir=%d  -Dydim0_advec_cell_kernel3_ydir=%d  -Dxdim1_advec_cell_kernel3_ydir=%d  -Dydim1_advec_cell_kernel3_ydir=%d  -Dxdim2_advec_cell_kernel3_ydir=%d  -Dydim2_advec_cell_kernel3_ydir=%d  -Dxdim3_advec_cell_kernel3_ydir=%d  -Dydim3_advec_cell_kernel3_ydir=%d  -Dxdim4_advec_cell_kernel3_ydir=%d  -Dydim4_advec_cell_kernel3_ydir=%d  -Dxdim5_advec_cell_kernel3_ydir=%d  -Dydim5_advec_cell_kernel3_ydir=%d  -Dxdim6_advec_cell_kernel3_ydir=%d  -Dydim6_advec_cell_kernel3_ydir=%d  -Dxdim7_advec_cell_kernel3_ydir=%d  -Dydim7_advec_cell_kernel3_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel3_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel3_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel3_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel3_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel3_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel3_zdir=%d  -Dydim0_advec_cell_kernel3_zdir=%d  -Dxdim1_advec_cell_kernel3_zdir=%d  -Dydim1_advec_cell_kernel3_zdir=%d  -Dxdim2_advec_cell_kernel3_zdir=%d  -Dydim2_advec_cell_kernel3_zdir=%d  -Dxdim3_advec_cell_kernel3_zdir=%d  -Dydim3_advec_cell_kernel3_zdir=%d  -Dxdim4_advec_cell_kernel3_zdir=%d  -Dydim4_advec_cell_kernel3_zdir=%d  -Dxdim5_advec_cell_kernel3_zdir=%d  -Dydim5_advec_cell_kernel3_zdir=%d  -Dxdim6_advec_cell_kernel3_zdir=%d  -Dydim6_advec_cell_kernel3_zdir=%d  -Dxdim7_advec_cell_kernel3_zdir=%d  -Dydim7_advec_cell_kernel3_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -178,14 +178,6 @@ void ops_par_loop_advec_cell_kernel3_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_xdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_xdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_xdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_xdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_xdir=%d  -Dydim0_advec_cell_kernel4_xdir=%d  -Dxdim1_advec_cell_kernel4_xdir=%d  -Dydim1_advec_cell_kernel4_xdir=%d  -Dxdim2_advec_cell_kernel4_xdir=%d  -Dydim2_advec_cell_kernel4_xdir=%d  -Dxdim3_advec_cell_kernel4_xdir=%d  -Dydim3_advec_cell_kernel4_xdir=%d  -Dxdim4_advec_cell_kernel4_xdir=%d  -Dydim4_advec_cell_kernel4_xdir=%d  -Dxdim5_advec_cell_kernel4_xdir=%d  -Dydim5_advec_cell_kernel4_xdir=%d  -Dxdim6_advec_cell_kernel4_xdir=%d  -Dydim6_advec_cell_kernel4_xdir=%d  -Dxdim7_advec_cell_kernel4_xdir=%d  -Dydim7_advec_cell_kernel4_xdir=%d  -Dxdim8_advec_cell_kernel4_xdir=%d  -Dydim8_advec_cell_kernel4_xdir=%d  -Dxdim9_advec_cell_kernel4_xdir=%d  -Dydim9_advec_cell_kernel4_xdir=%d  -Dxdim10_advec_cell_kernel4_xdir=%d  -Dydim10_advec_cell_kernel4_xdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_xdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_ydir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_ydir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_ydir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_ydir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_ydir=%d  -Dydim0_advec_cell_kernel4_ydir=%d  -Dxdim1_advec_cell_kernel4_ydir=%d  -Dydim1_advec_cell_kernel4_ydir=%d  -Dxdim2_advec_cell_kernel4_ydir=%d  -Dydim2_advec_cell_kernel4_ydir=%d  -Dxdim3_advec_cell_kernel4_ydir=%d  -Dydim3_advec_cell_kernel4_ydir=%d  -Dxdim4_advec_cell_kernel4_ydir=%d  -Dydim4_advec_cell_kernel4_ydir=%d  -Dxdim5_advec_cell_kernel4_ydir=%d  -Dydim5_advec_cell_kernel4_ydir=%d  -Dxdim6_advec_cell_kernel4_ydir=%d  -Dydim6_advec_cell_kernel4_ydir=%d  -Dxdim7_advec_cell_kernel4_ydir=%d  -Dydim7_advec_cell_kernel4_ydir=%d  -Dxdim8_advec_cell_kernel4_ydir=%d  -Dydim8_advec_cell_kernel4_ydir=%d  -Dxdim9_advec_cell_kernel4_ydir=%d  -Dydim9_advec_cell_kernel4_ydir=%d  -Dxdim10_advec_cell_kernel4_ydir=%d  -Dydim10_advec_cell_kernel4_ydir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_ydir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_zdir_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_cell_kernel4_zdir_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_cell_kernel4_zdir(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_cell_kernel4_zdir.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_cell_kernel4_zdir.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_cell_kernel4_zdir(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_cell_kernel4_zdir=%d  -Dydim0_advec_cell_kernel4_zdir=%d  -Dxdim1_advec_cell_kernel4_zdir=%d  -Dydim1_advec_cell_kernel4_zdir=%d  -Dxdim2_advec_cell_kernel4_zdir=%d  -Dydim2_advec_cell_kernel4_zdir=%d  -Dxdim3_advec_cell_kernel4_zdir=%d  -Dydim3_advec_cell_kernel4_zdir=%d  -Dxdim4_advec_cell_kernel4_zdir=%d  -Dydim4_advec_cell_kernel4_zdir=%d  -Dxdim5_advec_cell_kernel4_zdir=%d  -Dydim5_advec_cell_kernel4_zdir=%d  -Dxdim6_advec_cell_kernel4_zdir=%d  -Dydim6_advec_cell_kernel4_zdir=%d  -Dxdim7_advec_cell_kernel4_zdir=%d  -Dydim7_advec_cell_kernel4_zdir=%d  -Dxdim8_advec_cell_kernel4_zdir=%d  -Dydim8_advec_cell_kernel4_zdir=%d  -Dxdim9_advec_cell_kernel4_zdir=%d  -Dydim9_advec_cell_kernel4_zdir=%d  -Dxdim10_advec_cell_kernel4_zdir=%d  -Dydim10_advec_cell_kernel4_zdir=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -185,17 +185,6 @@ void ops_par_loop_advec_cell_kernel4_zdir(char const *name, ops_block block, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_x_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_x_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_x_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_x_nonvector=%d  -Dydim0_advec_mom_kernel1_x_nonvector=%d  -Dxdim1_advec_mom_kernel1_x_nonvector=%d  -Dydim1_advec_mom_kernel1_x_nonvector=%d  -Dxdim2_advec_mom_kernel1_x_nonvector=%d  -Dydim2_advec_mom_kernel1_x_nonvector=%d  -Dxdim3_advec_mom_kernel1_x_nonvector=%d  -Dydim3_advec_mom_kernel1_x_nonvector=%d  -Dxdim4_advec_mom_kernel1_x_nonvector=%d  -Dydim4_advec_mom_kernel1_x_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_x_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_y_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_y_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_y_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_y_nonvector=%d  -Dydim0_advec_mom_kernel1_y_nonvector=%d  -Dxdim1_advec_mom_kernel1_y_nonvector=%d  -Dydim1_advec_mom_kernel1_y_nonvector=%d  -Dxdim2_advec_mom_kernel1_y_nonvector=%d  -Dydim2_advec_mom_kernel1_y_nonvector=%d  -Dxdim3_advec_mom_kernel1_y_nonvector=%d  -Dydim3_advec_mom_kernel1_y_nonvector=%d  -Dxdim4_advec_mom_kernel1_y_nonvector=%d  -Dydim4_advec_mom_kernel1_y_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_y_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_z_nonvector_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel1_z_nonvector_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel1_z_nonvector(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel1_z_nonvector.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel1_z_nonvector.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel1_z_nonvector(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel1_z_nonvector=%d  -Dydim0_advec_mom_kernel1_z_nonvector=%d  -Dxdim1_advec_mom_kernel1_z_nonvector=%d  -Dydim1_advec_mom_kernel1_z_nonvector=%d  -Dxdim2_advec_mom_kernel1_z_nonvector=%d  -Dydim2_advec_mom_kernel1_z_nonvector=%d  -Dxdim3_advec_mom_kernel1_z_nonvector=%d  -Dydim3_advec_mom_kernel1_z_nonvector=%d  -Dxdim4_advec_mom_kernel1_z_nonvector=%d  -Dydim4_advec_mom_kernel1_z_nonvector=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel1_z_nonvector(char const *name, ops_block bloc
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_x(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_x=%d  -Dydim0_advec_mom_kernel2_x=%d  -Dxdim1_advec_mom_kernel2_x=%d  -Dydim1_advec_mom_kernel2_x=%d  -Dxdim2_advec_mom_kernel2_x=%d  -Dydim2_advec_mom_kernel2_x=%d  -Dxdim3_advec_mom_kernel2_x=%d  -Dydim3_advec_mom_kernel2_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_x(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_y(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_y=%d  -Dydim0_advec_mom_kernel2_y=%d  -Dxdim1_advec_mom_kernel2_y=%d  -Dydim1_advec_mom_kernel2_y=%d  -Dxdim2_advec_mom_kernel2_y=%d  -Dydim2_advec_mom_kernel2_y=%d  -Dxdim3_advec_mom_kernel2_y=%d  -Dydim3_advec_mom_kernel2_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_y(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel2_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel2_z(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel2_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel2_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel2_z(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel2_z=%d  -Dydim0_advec_mom_kernel2_z=%d  -Dxdim1_advec_mom_kernel2_z=%d  -Dydim1_advec_mom_kernel2_z=%d  -Dxdim2_advec_mom_kernel2_z=%d  -Dydim2_advec_mom_kernel2_z=%d  -Dxdim3_advec_mom_kernel2_z=%d  -Dydim3_advec_mom_kernel2_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel2_z(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_x(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_x=%d  -Dydim0_advec_mom_kernel_mass_flux_x=%d  -Dxdim1_advec_mom_kernel_mass_flux_x=%d  -Dydim1_advec_mom_kernel_mass_flux_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_x(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_y(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_y=%d  -Dydim0_advec_mom_kernel_mass_flux_y=%d  -Dxdim1_advec_mom_kernel_mass_flux_y=%d  -Dydim1_advec_mom_kernel_mass_flux_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_y(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_mass_flux_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_z(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_mass_flux_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_mass_flux_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_mass_flux_z(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_mass_flux_z=%d  -Dydim0_advec_mom_kernel_mass_flux_z=%d  -Dxdim1_advec_mom_kernel_mass_flux_z=%d  -Dydim1_advec_mom_kernel_mass_flux_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,8 +165,6 @@ void ops_par_loop_advec_mom_kernel_mass_flux_z(char const *name, ops_block block
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_x_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_x.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_x(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_x=%d  -Dydim0_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_x=%d  -Dydim1_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_x=%d  -Dydim2_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_x=%d  -Dydim3_advec_mom_kernel_post_pre_advec_x=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_x=%d  -Dydim4_advec_mom_kernel_post_pre_advec_x=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_x(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_y_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_y.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_y(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_y=%d  -Dydim0_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_y=%d  -Dydim1_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_y=%d  -Dydim2_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_y=%d  -Dydim3_advec_mom_kernel_post_pre_advec_y=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_y=%d  -Dydim4_advec_mom_kernel_post_pre_advec_y=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_y(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_z_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_post_pre_advec_z_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_z(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_post_pre_advec_z.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_post_pre_advec_z.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_post_pre_advec_z(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_post_pre_advec_z=%d  -Dydim0_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim1_advec_mom_kernel_post_pre_advec_z=%d  -Dydim1_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim2_advec_mom_kernel_post_pre_advec_z=%d  -Dydim2_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim3_advec_mom_kernel_post_pre_advec_z=%d  -Dydim3_advec_mom_kernel_post_pre_advec_z=%d  -Dxdim4_advec_mom_kernel_post_pre_advec_z=%d  -Dydim4_advec_mom_kernel_post_pre_advec_z=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_post_pre_advec_z(char const *name, ops_block 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x1=%d  -Dydim0_advec_mom_kernel_x1=%d  -Dxdim1_advec_mom_kernel_x1=%d  -Dydim1_advec_mom_kernel_x1=%d  -Dxdim2_advec_mom_kernel_x1=%d  -Dydim2_advec_mom_kernel_x1=%d  -Dxdim3_advec_mom_kernel_x1=%d  -Dydim3_advec_mom_kernel_x1=%d  -Dxdim4_advec_mom_kernel_x1=%d  -Dydim4_advec_mom_kernel_x1=%d  -Dxdim5_advec_mom_kernel_x1=%d  -Dydim5_advec_mom_kernel_x1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_mom_kernel_x1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x2=%d  -Dydim0_advec_mom_kernel_x2=%d  -Dxdim1_advec_mom_kernel_x2=%d  -Dydim1_advec_mom_kernel_x2=%d  -Dxdim2_advec_mom_kernel_x2=%d  -Dydim2_advec_mom_kernel_x2=%d  -Dxdim3_advec_mom_kernel_x2=%d  -Dydim3_advec_mom_kernel_x2=%d  -Dxdim4_advec_mom_kernel_x2=%d  -Dydim4_advec_mom_kernel_x2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_x2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x3_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_x3_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_x3(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_x3.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_x3.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_x3(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_x3=%d  -Dydim0_advec_mom_kernel_x3=%d  -Dxdim1_advec_mom_kernel_x3=%d  -Dydim1_advec_mom_kernel_x3=%d  -Dxdim2_advec_mom_kernel_x3=%d  -Dydim2_advec_mom_kernel_x3=%d  -Dxdim3_advec_mom_kernel_x3=%d  -Dydim3_advec_mom_kernel_x3=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel_x3(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_y2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_y2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_y2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_y2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_y2=%d  -Dydim0_advec_mom_kernel_y2=%d  -Dxdim1_advec_mom_kernel_y2=%d  -Dydim1_advec_mom_kernel_y2=%d  -Dxdim2_advec_mom_kernel_y2=%d  -Dydim2_advec_mom_kernel_y2=%d  -Dxdim3_advec_mom_kernel_y2=%d  -Dydim3_advec_mom_kernel_y2=%d  -Dxdim4_advec_mom_kernel_y2=%d  -Dydim4_advec_mom_kernel_y2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,11 +172,6 @@ void ops_par_loop_advec_mom_kernel_y2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_z1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_z1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_z1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_z1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_z1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_z1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_z1=%d  -Dydim0_advec_mom_kernel_z1=%d  -Dxdim1_advec_mom_kernel_z1=%d  -Dydim1_advec_mom_kernel_z1=%d  -Dxdim2_advec_mom_kernel_z1=%d  -Dydim2_advec_mom_kernel_z1=%d  -Dxdim3_advec_mom_kernel_z1=%d  -Dydim3_advec_mom_kernel_z1=%d  -Dxdim4_advec_mom_kernel_z1=%d  -Dydim4_advec_mom_kernel_z1=%d  -Dxdim5_advec_mom_kernel_z1=%d  -Dydim5_advec_mom_kernel_z1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_advec_mom_kernel_z1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_z3_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/advec_mom_kernel_z3_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_advec_mom_kernel_z3(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/advec_mom_kernel_z3.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/advec_mom_kernel_z3.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_advec_mom_kernel_z3(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_advec_mom_kernel_z3=%d  -Dydim0_advec_mom_kernel_z3=%d  -Dxdim1_advec_mom_kernel_z3=%d  -Dydim1_advec_mom_kernel_z3=%d  -Dxdim2_advec_mom_kernel_z3=%d  -Dydim2_advec_mom_kernel_z3=%d  -Dxdim3_advec_mom_kernel_z3=%d  -Dydim3_advec_mom_kernel_z3=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_advec_mom_kernel_z3(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_get_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int ydim0, int xdim1, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_get.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_get.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_get(int xdim0, int ydim0, int xdim1, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_get=%d  -Dydim0_calc_dt_kernel_get=%d  -Dxdim1_calc_dt_kernel_get=%d  -Dydim1_calc_dt_kernel_get=%d  -Dxdim4_calc_dt_kernel_get=%d  -Dydim4_calc_dt_kernel_get=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim4,ydim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -215,9 +215,6 @@ void ops_par_loop_calc_dt_kernel_get(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_min_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0, int ydim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_min.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_min.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_min(int xdim0, int ydim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_min=%d  -Dydim0_calc_dt_kernel_min=%d ", pPath, 32,xdim0,ydim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -184,7 +184,6 @@ void ops_par_loop_calc_dt_kernel_min(char const *name, ops_block block, int dim,
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int ydim0, int xdim1, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel(int xdim0, int ydim0, int xdim1, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel=%d  -Dydim0_calc_dt_kernel=%d  -Dxdim1_calc_dt_kernel=%d  -Dydim1_calc_dt_kernel=%d  -Dxdim2_calc_dt_kernel=%d  -Dydim2_calc_dt_kernel=%d  -Dxdim3_calc_dt_kernel=%d  -Dydim3_calc_dt_kernel=%d  -Dxdim4_calc_dt_kernel=%d  -Dydim4_calc_dt_kernel=%d  -Dxdim5_calc_dt_kernel=%d  -Dydim5_calc_dt_kernel=%d  -Dxdim6_calc_dt_kernel=%d  -Dydim6_calc_dt_kernel=%d  -Dxdim7_calc_dt_kernel=%d  -Dydim7_calc_dt_kernel=%d  -Dxdim8_calc_dt_kernel=%d  -Dydim8_calc_dt_kernel=%d  -Dxdim9_calc_dt_kernel=%d  -Dydim9_calc_dt_kernel=%d  -Dxdim10_calc_dt_kernel=%d  -Dydim10_calc_dt_kernel=%d  -Dxdim11_calc_dt_kernel=%d  -Dydim11_calc_dt_kernel=%d  -Dxdim12_calc_dt_kernel=%d  -Dydim12_calc_dt_kernel=%d  -Dxdim13_calc_dt_kernel=%d  -Dydim13_calc_dt_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11,xdim12,ydim12,xdim13,ydim13);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -191,20 +191,6 @@ void ops_par_loop_calc_dt_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
-  int dat12 = args[12].dat->elem_size;
-  int dat13 = args[13].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/calc_dt_kernel_print_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calc_dt_kernel_print.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calc_dt_kernel_print.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calc_dt_kernel_print(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calc_dt_kernel_print=%d  -Dydim0_calc_dt_kernel_print=%d  -Dxdim1_calc_dt_kernel_print=%d  -Dydim1_calc_dt_kernel_print=%d  -Dxdim2_calc_dt_kernel_print=%d  -Dydim2_calc_dt_kernel_print=%d  -Dxdim3_calc_dt_kernel_print=%d  -Dydim3_calc_dt_kernel_print=%d  -Dxdim4_calc_dt_kernel_print=%d  -Dydim4_calc_dt_kernel_print=%d  -Dxdim5_calc_dt_kernel_print=%d  -Dydim5_calc_dt_kernel_print=%d  -Dxdim6_calc_dt_kernel_print=%d  -Dydim6_calc_dt_kernel_print=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -197,13 +197,6 @@ void ops_par_loop_calc_dt_kernel_print(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/field_summary_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/field_summary_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int ydim0, int xdim1, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/field_summary_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/field_summary_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_field_summary_kernel(int xdim0, int ydim0, int xdim1, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_field_summary_kernel=%d  -Dydim0_field_summary_kernel=%d  -Dxdim1_field_summary_kernel=%d  -Dydim1_field_summary_kernel=%d  -Dxdim2_field_summary_kernel=%d  -Dydim2_field_summary_kernel=%d  -Dxdim3_field_summary_kernel=%d  -Dydim3_field_summary_kernel=%d  -Dxdim4_field_summary_kernel=%d  -Dydim4_field_summary_kernel=%d  -Dxdim5_field_summary_kernel=%d  -Dydim5_field_summary_kernel=%d  -Dxdim6_field_summary_kernel=%d  -Dydim6_field_summary_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -250,13 +250,6 @@ void ops_par_loop_field_summary_kernel(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernelx_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernelx.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernelx.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernelx(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernelx=%d  -Dydim0_flux_calc_kernelx=%d  -Dxdim1_flux_calc_kernelx=%d  -Dydim1_flux_calc_kernelx=%d  -Dxdim2_flux_calc_kernelx=%d  -Dydim2_flux_calc_kernelx=%d  -Dxdim3_flux_calc_kernelx=%d  -Dydim3_flux_calc_kernelx=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernelx(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernely_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernely_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernely.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernely.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernely(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernely=%d  -Dydim0_flux_calc_kernely=%d  -Dxdim1_flux_calc_kernely=%d  -Dydim1_flux_calc_kernely=%d  -Dxdim2_flux_calc_kernely=%d  -Dydim2_flux_calc_kernely=%d  -Dxdim3_flux_calc_kernely=%d  -Dydim3_flux_calc_kernely=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernely(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernelz_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/flux_calc_kernelz_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_flux_calc_kernelz(int xdim0, int ydim0, int xdim1, int y
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/flux_calc_kernelz.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/flux_calc_kernelz.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_flux_calc_kernelz(int xdim0, int ydim0, int xdim1, int y
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_flux_calc_kernelz=%d  -Dydim0_flux_calc_kernelz=%d  -Dxdim1_flux_calc_kernelz=%d  -Dydim1_flux_calc_kernelz=%d  -Dxdim2_flux_calc_kernelz=%d  -Dydim2_flux_calc_kernelz=%d  -Dxdim3_flux_calc_kernelz=%d  -Dydim3_flux_calc_kernelz=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_flux_calc_kernelz(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/ideal_gas_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int ydim0, int xdim1, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/ideal_gas_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/ideal_gas_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_ideal_gas_kernel(int xdim0, int ydim0, int xdim1, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_ideal_gas_kernel=%d  -Dydim0_ideal_gas_kernel=%d  -Dxdim1_ideal_gas_kernel=%d  -Dydim1_ideal_gas_kernel=%d  -Dxdim2_ideal_gas_kernel=%d  -Dydim2_ideal_gas_kernel=%d  -Dxdim3_ideal_gas_kernel=%d  -Dydim3_ideal_gas_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_ideal_gas_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/reset_field_kernel1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/reset_field_kernel1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel1(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel1=%d  -Dydim0_reset_field_kernel1=%d  -Dxdim1_reset_field_kernel1=%d  -Dydim1_reset_field_kernel1=%d  -Dxdim2_reset_field_kernel1=%d  -Dydim2_reset_field_kernel1=%d  -Dxdim3_reset_field_kernel1=%d  -Dydim3_reset_field_kernel1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_reset_field_kernel1(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/reset_field_kernel2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/reset_field_kernel2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int ydim0, int xdim1, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/reset_field_kernel2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/reset_field_kernel2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_reset_field_kernel2(int xdim0, int ydim0, int xdim1, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_reset_field_kernel2=%d  -Dydim0_reset_field_kernel2=%d  -Dxdim1_reset_field_kernel2=%d  -Dydim1_reset_field_kernel2=%d  -Dxdim2_reset_field_kernel2=%d  -Dydim2_reset_field_kernel2=%d  -Dxdim3_reset_field_kernel2=%d  -Dydim3_reset_field_kernel2=%d  -Dxdim4_reset_field_kernel2=%d  -Dydim4_reset_field_kernel2=%d  -Dxdim5_reset_field_kernel2=%d  -Dydim5_reset_field_kernel2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -174,12 +174,6 @@ void ops_par_loop_reset_field_kernel2(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/revert_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/revert_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int ydim0, int xdim1, int ydim1
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/revert_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/revert_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_revert_kernel(int xdim0, int ydim0, int xdim1, int ydim1
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_revert_kernel=%d  -Dydim0_revert_kernel=%d  -Dxdim1_revert_kernel=%d  -Dydim1_revert_kernel=%d  -Dxdim2_revert_kernel=%d  -Dydim2_revert_kernel=%d  -Dxdim3_revert_kernel=%d  -Dydim3_revert_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,10 +169,6 @@ void ops_par_loop_revert_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_b1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b1=%d  -Dydim0_update_halo_kernel1_b1=%d  -Dxdim1_update_halo_kernel1_b1=%d  -Dydim1_update_halo_kernel1_b1=%d  -Dxdim2_update_halo_kernel1_b1=%d  -Dydim2_update_halo_kernel1_b1=%d  -Dxdim3_update_halo_kernel1_b1=%d  -Dydim3_update_halo_kernel1_b1=%d  -Dxdim4_update_halo_kernel1_b1=%d  -Dydim4_update_halo_kernel1_b1=%d  -Dxdim5_update_halo_kernel1_b1=%d  -Dydim5_update_halo_kernel1_b1=%d  -Dxdim6_update_halo_kernel1_b1=%d  -Dydim6_update_halo_kernel1_b1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_b1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_b2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_b2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_b2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_b2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_b2=%d  -Dydim0_update_halo_kernel1_b2=%d  -Dxdim1_update_halo_kernel1_b2=%d  -Dydim1_update_halo_kernel1_b2=%d  -Dxdim2_update_halo_kernel1_b2=%d  -Dydim2_update_halo_kernel1_b2=%d  -Dxdim3_update_halo_kernel1_b2=%d  -Dydim3_update_halo_kernel1_b2=%d  -Dxdim4_update_halo_kernel1_b2=%d  -Dydim4_update_halo_kernel1_b2=%d  -Dxdim5_update_halo_kernel1_b2=%d  -Dydim5_update_halo_kernel1_b2=%d  -Dxdim6_update_halo_kernel1_b2=%d  -Dydim6_update_halo_kernel1_b2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_b2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_ba1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_ba1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba1(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_ba1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_ba1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba1(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_ba1=%d  -Dydim0_update_halo_kernel1_ba1=%d  -Dxdim1_update_halo_kernel1_ba1=%d  -Dydim1_update_halo_kernel1_ba1=%d  -Dxdim2_update_halo_kernel1_ba1=%d  -Dydim2_update_halo_kernel1_ba1=%d  -Dxdim3_update_halo_kernel1_ba1=%d  -Dydim3_update_halo_kernel1_ba1=%d  -Dxdim4_update_halo_kernel1_ba1=%d  -Dydim4_update_halo_kernel1_ba1=%d  -Dxdim5_update_halo_kernel1_ba1=%d  -Dydim5_update_halo_kernel1_ba1=%d  -Dxdim6_update_halo_kernel1_ba1=%d  -Dydim6_update_halo_kernel1_ba1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_ba1(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_ba2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_ba2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba2(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_ba2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_ba2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_ba2(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_ba2=%d  -Dydim0_update_halo_kernel1_ba2=%d  -Dxdim1_update_halo_kernel1_ba2=%d  -Dydim1_update_halo_kernel1_ba2=%d  -Dxdim2_update_halo_kernel1_ba2=%d  -Dydim2_update_halo_kernel1_ba2=%d  -Dxdim3_update_halo_kernel1_ba2=%d  -Dydim3_update_halo_kernel1_ba2=%d  -Dxdim4_update_halo_kernel1_ba2=%d  -Dydim4_update_halo_kernel1_ba2=%d  -Dxdim5_update_halo_kernel1_ba2=%d  -Dydim5_update_halo_kernel1_ba2=%d  -Dxdim6_update_halo_kernel1_ba2=%d  -Dydim6_update_halo_kernel1_ba2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_ba2(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_fr1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_fr1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr1(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_fr1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_fr1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr1(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_fr1=%d  -Dydim0_update_halo_kernel1_fr1=%d  -Dxdim1_update_halo_kernel1_fr1=%d  -Dydim1_update_halo_kernel1_fr1=%d  -Dxdim2_update_halo_kernel1_fr1=%d  -Dydim2_update_halo_kernel1_fr1=%d  -Dxdim3_update_halo_kernel1_fr1=%d  -Dydim3_update_halo_kernel1_fr1=%d  -Dxdim4_update_halo_kernel1_fr1=%d  -Dydim4_update_halo_kernel1_fr1=%d  -Dxdim5_update_halo_kernel1_fr1=%d  -Dydim5_update_halo_kernel1_fr1=%d  -Dxdim6_update_halo_kernel1_fr1=%d  -Dydim6_update_halo_kernel1_fr1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_fr1(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_fr2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_fr2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr2(int xdim0, int ydim0, int xdim1,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_fr2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_fr2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_fr2(int xdim0, int ydim0, int xdim1,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_fr2=%d  -Dydim0_update_halo_kernel1_fr2=%d  -Dxdim1_update_halo_kernel1_fr2=%d  -Dydim1_update_halo_kernel1_fr2=%d  -Dxdim2_update_halo_kernel1_fr2=%d  -Dydim2_update_halo_kernel1_fr2=%d  -Dxdim3_update_halo_kernel1_fr2=%d  -Dydim3_update_halo_kernel1_fr2=%d  -Dxdim4_update_halo_kernel1_fr2=%d  -Dydim4_update_halo_kernel1_fr2=%d  -Dxdim5_update_halo_kernel1_fr2=%d  -Dydim5_update_halo_kernel1_fr2=%d  -Dxdim6_update_halo_kernel1_fr2=%d  -Dydim6_update_halo_kernel1_fr2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_fr2(char const *name, ops_block block, int
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_l1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l1=%d  -Dydim0_update_halo_kernel1_l1=%d  -Dxdim1_update_halo_kernel1_l1=%d  -Dydim1_update_halo_kernel1_l1=%d  -Dxdim2_update_halo_kernel1_l1=%d  -Dydim2_update_halo_kernel1_l1=%d  -Dxdim3_update_halo_kernel1_l1=%d  -Dydim3_update_halo_kernel1_l1=%d  -Dxdim4_update_halo_kernel1_l1=%d  -Dydim4_update_halo_kernel1_l1=%d  -Dxdim5_update_halo_kernel1_l1=%d  -Dydim5_update_halo_kernel1_l1=%d  -Dxdim6_update_halo_kernel1_l1=%d  -Dydim6_update_halo_kernel1_l1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_l1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_l2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_l2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_l2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_l2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_l2=%d  -Dydim0_update_halo_kernel1_l2=%d  -Dxdim1_update_halo_kernel1_l2=%d  -Dydim1_update_halo_kernel1_l2=%d  -Dxdim2_update_halo_kernel1_l2=%d  -Dydim2_update_halo_kernel1_l2=%d  -Dxdim3_update_halo_kernel1_l2=%d  -Dydim3_update_halo_kernel1_l2=%d  -Dxdim4_update_halo_kernel1_l2=%d  -Dydim4_update_halo_kernel1_l2=%d  -Dxdim5_update_halo_kernel1_l2=%d  -Dydim5_update_halo_kernel1_l2=%d  -Dxdim6_update_halo_kernel1_l2=%d  -Dydim6_update_halo_kernel1_l2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_l2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_r1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r1=%d  -Dydim0_update_halo_kernel1_r1=%d  -Dxdim1_update_halo_kernel1_r1=%d  -Dydim1_update_halo_kernel1_r1=%d  -Dxdim2_update_halo_kernel1_r1=%d  -Dydim2_update_halo_kernel1_r1=%d  -Dxdim3_update_halo_kernel1_r1=%d  -Dydim3_update_halo_kernel1_r1=%d  -Dxdim4_update_halo_kernel1_r1=%d  -Dydim4_update_halo_kernel1_r1=%d  -Dxdim5_update_halo_kernel1_r1=%d  -Dydim5_update_halo_kernel1_r1=%d  -Dxdim6_update_halo_kernel1_r1=%d  -Dydim6_update_halo_kernel1_r1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_r1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_r2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_r2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_r2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_r2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_r2=%d  -Dydim0_update_halo_kernel1_r2=%d  -Dxdim1_update_halo_kernel1_r2=%d  -Dydim1_update_halo_kernel1_r2=%d  -Dxdim2_update_halo_kernel1_r2=%d  -Dydim2_update_halo_kernel1_r2=%d  -Dxdim3_update_halo_kernel1_r2=%d  -Dydim3_update_halo_kernel1_r2=%d  -Dxdim4_update_halo_kernel1_r2=%d  -Dydim4_update_halo_kernel1_r2=%d  -Dxdim5_update_halo_kernel1_r2=%d  -Dydim5_update_halo_kernel1_r2=%d  -Dxdim6_update_halo_kernel1_r2=%d  -Dydim6_update_halo_kernel1_r2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_r2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_t1_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t1.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t1.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t1(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t1=%d  -Dydim0_update_halo_kernel1_t1=%d  -Dxdim1_update_halo_kernel1_t1=%d  -Dydim1_update_halo_kernel1_t1=%d  -Dxdim2_update_halo_kernel1_t1=%d  -Dydim2_update_halo_kernel1_t1=%d  -Dxdim3_update_halo_kernel1_t1=%d  -Dydim3_update_halo_kernel1_t1=%d  -Dxdim4_update_halo_kernel1_t1=%d  -Dydim4_update_halo_kernel1_t1=%d  -Dxdim5_update_halo_kernel1_t1=%d  -Dydim5_update_halo_kernel1_t1=%d  -Dxdim6_update_halo_kernel1_t1=%d  -Dydim6_update_halo_kernel1_t1=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_t1(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel1_t2_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int ydim0, int xdim1, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel1_t2.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel1_t2.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel1_t2(int xdim0, int ydim0, int xdim1, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel1_t2=%d  -Dydim0_update_halo_kernel1_t2=%d  -Dxdim1_update_halo_kernel1_t2=%d  -Dydim1_update_halo_kernel1_t2=%d  -Dxdim2_update_halo_kernel1_t2=%d  -Dydim2_update_halo_kernel1_t2=%d  -Dxdim3_update_halo_kernel1_t2=%d  -Dydim3_update_halo_kernel1_t2=%d  -Dxdim4_update_halo_kernel1_t2=%d  -Dydim4_update_halo_kernel1_t2=%d  -Dxdim5_update_halo_kernel1_t2=%d  -Dydim5_update_halo_kernel1_t2=%d  -Dxdim6_update_halo_kernel1_t2=%d  -Dydim6_update_halo_kernel1_t2=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,13 +187,6 @@ void ops_par_loop_update_halo_kernel1_t2(char const *name, ops_block block, int 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg7.data)[d] = arg7h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_left(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_left(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_left=%d  -Dydim0_update_halo_kernel2_xvel_minus_2_left=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_left=%d  -Dydim1_update_halo_kernel2_xvel_minus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_left(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_right(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_2_right(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_2_right=%d  -Dydim0_update_halo_kernel2_xvel_minus_2_right=%d  -Dxdim1_update_halo_kernel2_xvel_minus_2_right=%d  -Dydim1_update_halo_kernel2_xvel_minus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_2_right(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_left(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_left(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_left=%d  -Dydim0_update_halo_kernel2_xvel_minus_4_left=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_left=%d  -Dydim1_update_halo_kernel2_xvel_minus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_left(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_minus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_right(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_minus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_minus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_minus_4_right(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_minus_4_right=%d  -Dydim0_update_halo_kernel2_xvel_minus_4_right=%d  -Dxdim1_update_halo_kernel2_xvel_minus_4_right=%d  -Dydim1_update_halo_kernel2_xvel_minus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_minus_4_right(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_back=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_back=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_back=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_bot=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_bot=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_bot=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_front=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_front=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_front=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_2_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_2_top=%d  -Dydim0_update_halo_kernel2_xvel_plus_2_top=%d  -Dxdim1_update_halo_kernel2_xvel_plus_2_top=%d  -Dydim1_update_halo_kernel2_xvel_plus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_2_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_back=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_back=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_back=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_bot=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_bot=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_bot=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_front=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_front=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_front=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_xvel_plus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_xvel_plus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_xvel_plus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_xvel_plus_4_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_xvel_plus_4_top=%d  -Dydim0_update_halo_kernel2_xvel_plus_4_top=%d  -Dxdim1_update_halo_kernel2_xvel_plus_4_top=%d  -Dydim1_update_halo_kernel2_xvel_plus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_xvel_plus_4_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_bot(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_bot(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_bot=%d  -Dydim0_update_halo_kernel2_yvel_minus_2_bot=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_bot=%d  -Dydim1_update_halo_kernel2_yvel_minus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_bot(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_top(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_2_top(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_2_top=%d  -Dydim0_update_halo_kernel2_yvel_minus_2_top=%d  -Dxdim1_update_halo_kernel2_yvel_minus_2_top=%d  -Dydim1_update_halo_kernel2_yvel_minus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_2_top(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_bot(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_bot(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_bot=%d  -Dydim0_update_halo_kernel2_yvel_minus_4_bot=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_bot=%d  -Dydim1_update_halo_kernel2_yvel_minus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_bot(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_minus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_top(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_minus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_minus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_minus_4_top(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_minus_4_top=%d  -Dydim0_update_halo_kernel2_yvel_minus_4_top=%d  -Dxdim1_update_halo_kernel2_yvel_minus_4_top=%d  -Dydim1_update_halo_kernel2_yvel_minus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_minus_4_top(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_back=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_back=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_back=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_front=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_front=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_front=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_left=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_left=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_left=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_2_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_2_right=%d  -Dydim0_update_halo_kernel2_yvel_plus_2_right=%d  -Dxdim1_update_halo_kernel2_yvel_plus_2_right=%d  -Dydim1_update_halo_kernel2_yvel_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_2_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_back(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_back(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_back=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_back=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_back=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_back(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_front(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_front(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_front=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_front=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_front=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_front(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_left=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_left=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_left=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_yvel_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_yvel_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_yvel_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_yvel_plus_4_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_yvel_plus_4_right=%d  -Dydim0_update_halo_kernel2_yvel_plus_4_right=%d  -Dxdim1_update_halo_kernel2_yvel_plus_4_right=%d  -Dydim1_update_halo_kernel2_yvel_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_yvel_plus_4_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_back(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_back(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_2_back=%d  -Dydim0_update_halo_kernel2_zvel_minus_2_back=%d  -Dxdim1_update_halo_kernel2_zvel_minus_2_back=%d  -Dydim1_update_halo_kernel2_zvel_minus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_2_back(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_front(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_2_front(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_2_front=%d  -Dydim0_update_halo_kernel2_zvel_minus_2_front=%d  -Dxdim1_update_halo_kernel2_zvel_minus_2_front=%d  -Dydim1_update_halo_kernel2_zvel_minus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_2_front(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_back(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_back(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_4_back=%d  -Dydim0_update_halo_kernel2_zvel_minus_4_back=%d  -Dxdim1_update_halo_kernel2_zvel_minus_4_back=%d  -Dydim1_update_halo_kernel2_zvel_minus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_4_back(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_minus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_front(int xdim0, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_minus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_minus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_minus_4_front(int xdim0, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_minus_4_front=%d  -Dydim0_update_halo_kernel2_zvel_minus_4_front=%d  -Dxdim1_update_halo_kernel2_zvel_minus_4_front=%d  -Dydim1_update_halo_kernel2_zvel_minus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_minus_4_front(char const *name, ops_b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_bot=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_bot=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_bot=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_left=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_left=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_left=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_right=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_right=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_right=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_2_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_2_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_2_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_2_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_2_top=%d  -Dydim0_update_halo_kernel2_zvel_plus_2_top=%d  -Dxdim1_update_halo_kernel2_zvel_plus_2_top=%d  -Dydim1_update_halo_kernel2_zvel_plus_2_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_2_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_bot_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_bot_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_bot(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_bot.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_bot.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_bot(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_bot=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_bot=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_bot=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_bot=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_bot(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_left(int xdim0, int ydim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_left(int xdim0, int ydim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_left=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_left=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_left=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_left(char const *name, ops_blo
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_right(int xdim0, int ydi
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_right(int xdim0, int ydi
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_right=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_right=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_right=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_right(char const *name, ops_bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_top_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel2_zvel_plus_4_top_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_top(int xdim0, int ydim0
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel2_zvel_plus_4_top.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel2_zvel_plus_4_top.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel2_zvel_plus_4_top(int xdim0, int ydim0
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel2_zvel_plus_4_top=%d  -Dydim0_update_halo_kernel2_zvel_plus_4_top=%d  -Dxdim1_update_halo_kernel2_zvel_plus_4_top=%d  -Dydim1_update_halo_kernel2_zvel_plus_4_top=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel2_zvel_plus_4_top(char const *name, ops_bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_a=%d  -Dydim0_update_halo_kernel3_minus_2_a=%d  -Dxdim1_update_halo_kernel3_minus_2_a=%d  -Dydim1_update_halo_kernel3_minus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_2_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_2_b=%d  -Dydim0_update_halo_kernel3_minus_2_b=%d  -Dxdim1_update_halo_kernel3_minus_2_b=%d  -Dydim1_update_halo_kernel3_minus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_a=%d  -Dydim0_update_halo_kernel3_minus_4_a=%d  -Dxdim1_update_halo_kernel3_minus_4_a=%d  -Dydim1_update_halo_kernel3_minus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_minus_4_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_minus_4_b=%d  -Dydim0_update_halo_kernel3_minus_4_b=%d  -Dxdim1_update_halo_kernel3_minus_4_b=%d  -Dydim1_update_halo_kernel3_minus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_a=%d  -Dydim0_update_halo_kernel3_plus_2_a=%d  -Dxdim1_update_halo_kernel3_plus_2_a=%d  -Dydim1_update_halo_kernel3_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_b=%d  -Dydim0_update_halo_kernel3_plus_2_b=%d  -Dxdim1_update_halo_kernel3_plus_2_b=%d  -Dydim1_update_halo_kernel3_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_back=%d  -Dydim0_update_halo_kernel3_plus_2_back=%d  -Dxdim1_update_halo_kernel3_plus_2_back=%d  -Dydim1_update_halo_kernel3_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_2_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_2_front=%d  -Dydim0_update_halo_kernel3_plus_2_front=%d  -Dxdim1_update_halo_kernel3_plus_2_front=%d  -Dydim1_update_halo_kernel3_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_2_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_a=%d  -Dydim0_update_halo_kernel3_plus_4_a=%d  -Dxdim1_update_halo_kernel3_plus_4_a=%d  -Dydim1_update_halo_kernel3_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_b=%d  -Dydim0_update_halo_kernel3_plus_4_b=%d  -Dxdim1_update_halo_kernel3_plus_4_b=%d  -Dydim1_update_halo_kernel3_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_back=%d  -Dydim0_update_halo_kernel3_plus_4_back=%d  -Dxdim1_update_halo_kernel3_plus_4_back=%d  -Dydim1_update_halo_kernel3_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel3_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel3_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel3_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel3_plus_4_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel3_plus_4_front=%d  -Dydim0_update_halo_kernel3_plus_4_front=%d  -Dxdim1_update_halo_kernel3_plus_4_front=%d  -Dydim1_update_halo_kernel3_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel3_plus_4_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_a=%d  -Dydim0_update_halo_kernel4_minus_2_a=%d  -Dxdim1_update_halo_kernel4_minus_2_a=%d  -Dydim1_update_halo_kernel4_minus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_2_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_2_b=%d  -Dydim0_update_halo_kernel4_minus_2_b=%d  -Dxdim1_update_halo_kernel4_minus_2_b=%d  -Dydim1_update_halo_kernel4_minus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_2_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_a(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_a=%d  -Dydim0_update_halo_kernel4_minus_4_a=%d  -Dxdim1_update_halo_kernel4_minus_4_a=%d  -Dydim1_update_halo_kernel4_minus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_a(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_minus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int ydim0, int 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_minus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_minus_4_b(int xdim0, int ydim0, int 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_minus_4_b=%d  -Dydim0_update_halo_kernel4_minus_4_b=%d  -Dxdim1_update_halo_kernel4_minus_4_b=%d  -Dydim1_update_halo_kernel4_minus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_minus_4_b(char const *name, ops_block bloc
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_a=%d  -Dydim0_update_halo_kernel4_plus_2_a=%d  -Dxdim1_update_halo_kernel4_plus_2_a=%d  -Dydim1_update_halo_kernel4_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_b=%d  -Dydim0_update_halo_kernel4_plus_2_b=%d  -Dxdim1_update_halo_kernel4_plus_2_b=%d  -Dydim1_update_halo_kernel4_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_back=%d  -Dydim0_update_halo_kernel4_plus_2_back=%d  -Dxdim1_update_halo_kernel4_plus_2_back=%d  -Dydim1_update_halo_kernel4_plus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_2_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_2_front=%d  -Dydim0_update_halo_kernel4_plus_2_front=%d  -Dxdim1_update_halo_kernel4_plus_2_front=%d  -Dydim1_update_halo_kernel4_plus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_2_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_a=%d  -Dydim0_update_halo_kernel4_plus_4_a=%d  -Dxdim1_update_halo_kernel4_plus_4_a=%d  -Dydim1_update_halo_kernel4_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_b=%d  -Dydim0_update_halo_kernel4_plus_4_b=%d  -Dxdim1_update_halo_kernel4_plus_4_b=%d  -Dydim1_update_halo_kernel4_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_back(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_back(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_back=%d  -Dydim0_update_halo_kernel4_plus_4_back=%d  -Dxdim1_update_halo_kernel4_plus_4_back=%d  -Dydim1_update_halo_kernel4_plus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_back(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel4_plus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_front(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel4_plus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel4_plus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel4_plus_4_front(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel4_plus_4_front=%d  -Dydim0_update_halo_kernel4_plus_4_front=%d  -Dxdim1_update_halo_kernel4_plus_4_front=%d  -Dydim1_update_halo_kernel4_plus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel4_plus_4_front(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_2_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_2_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_back(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_2_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_2_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_back(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_2_back=%d  -Dydim0_update_halo_kernel5_minus_2_back=%d  -Dxdim1_update_halo_kernel5_minus_2_back=%d  -Dydim1_update_halo_kernel5_minus_2_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_2_back(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_2_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_2_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_front(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_2_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_2_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_2_front(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_2_front=%d  -Dydim0_update_halo_kernel5_minus_2_front=%d  -Dxdim1_update_halo_kernel5_minus_2_front=%d  -Dydim1_update_halo_kernel5_minus_2_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_2_front(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_4_back_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_4_back_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_back(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_4_back.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_4_back.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_back(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_4_back=%d  -Dydim0_update_halo_kernel5_minus_4_back=%d  -Dxdim1_update_halo_kernel5_minus_4_back=%d  -Dydim1_update_halo_kernel5_minus_4_back=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_4_back(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_4_front_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_minus_4_front_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_front(int xdim0, int ydim0, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_minus_4_front.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_minus_4_front.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_minus_4_front(int xdim0, int ydim0, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_minus_4_front=%d  -Dydim0_update_halo_kernel5_minus_4_front=%d  -Dxdim1_update_halo_kernel5_minus_4_front=%d  -Dydim1_update_halo_kernel5_minus_4_front=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_minus_4_front(char const *name, ops_block 
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_a=%d  -Dydim0_update_halo_kernel5_plus_2_a=%d  -Dxdim1_update_halo_kernel5_plus_2_a=%d  -Dydim1_update_halo_kernel5_plus_2_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_b=%d  -Dydim0_update_halo_kernel5_plus_2_b=%d  -Dxdim1_update_halo_kernel5_plus_2_b=%d  -Dydim1_update_halo_kernel5_plus_2_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_left(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_left(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_left=%d  -Dydim0_update_halo_kernel5_plus_2_left=%d  -Dxdim1_update_halo_kernel5_plus_2_left=%d  -Dydim1_update_halo_kernel5_plus_2_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_left(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_2_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_right(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_2_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_2_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_2_right(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_2_right=%d  -Dydim0_update_halo_kernel5_plus_2_right=%d  -Dxdim1_update_halo_kernel5_plus_2_right=%d  -Dydim1_update_halo_kernel5_plus_2_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_2_right(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_a_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_a_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_a(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_a.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_a.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_a(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_a=%d  -Dydim0_update_halo_kernel5_plus_4_a=%d  -Dxdim1_update_halo_kernel5_plus_4_a=%d  -Dydim1_update_halo_kernel5_plus_4_a=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_a(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_b_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_b_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_b(int xdim0, int ydim0, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_b.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_b.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_b(int xdim0, int ydim0, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_b=%d  -Dydim0_update_halo_kernel5_plus_4_b=%d  -Dxdim1_update_halo_kernel5_plus_4_b=%d  -Dydim1_update_halo_kernel5_plus_4_b=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_b(char const *name, ops_block block
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_left_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_left_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_left(int xdim0, int ydim0, in
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_left.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_left.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_left(int xdim0, int ydim0, in
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_left=%d  -Dydim0_update_halo_kernel5_plus_4_left=%d  -Dxdim1_update_halo_kernel5_plus_4_left=%d  -Dydim1_update_halo_kernel5_plus_4_left=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_left(char const *name, ops_block bl
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_right_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/update_halo_kernel5_plus_4_right_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_right(int xdim0, int ydim0, i
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_halo_kernel5_plus_4_right.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_halo_kernel5_plus_4_right.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_halo_kernel5_plus_4_right(int xdim0, int ydim0, i
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_halo_kernel5_plus_4_right=%d  -Dydim0_update_halo_kernel5_plus_4_right=%d  -Dxdim1_update_halo_kernel5_plus_4_right=%d  -Dydim1_update_halo_kernel5_plus_4_right=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -176,8 +176,6 @@ void ops_par_loop_update_halo_kernel5_plus_4_right(char const *name, ops_block b
   for (int d=0; d<NUM_FIELDS; d++) ((int *)arg2.data)[d] = arg2h[d];
   consts_bytes += ROUND_UP(NUM_FIELDS*sizeof(int));
   mvConstArraysToDevice(consts_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/OpenCL/viscosity_kernel_opencl_kernel.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/OpenCL/viscosity_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int ydim0, int xdim1, int yd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/viscosity_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/viscosity_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_viscosity_kernel(int xdim0, int ydim0, int xdim1, int yd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_viscosity_kernel=%d  -Dydim0_viscosity_kernel=%d  -Dxdim1_viscosity_kernel=%d  -Dydim1_viscosity_kernel=%d  -Dxdim2_viscosity_kernel=%d  -Dydim2_viscosity_kernel=%d  -Dxdim3_viscosity_kernel=%d  -Dydim3_viscosity_kernel=%d  -Dxdim4_viscosity_kernel=%d  -Dydim4_viscosity_kernel=%d  -Dxdim5_viscosity_kernel=%d  -Dydim5_viscosity_kernel=%d  -Dxdim6_viscosity_kernel=%d  -Dydim6_viscosity_kernel=%d  -Dxdim7_viscosity_kernel=%d  -Dydim7_viscosity_kernel=%d  -Dxdim8_viscosity_kernel=%d  -Dydim8_viscosity_kernel=%d  -Dxdim9_viscosity_kernel=%d  -Dydim9_viscosity_kernel=%d  -Dxdim10_viscosity_kernel=%d  -Dydim10_viscosity_kernel=%d  -Dxdim11_viscosity_kernel=%d  -Dydim11_viscosity_kernel=%d ", pPath, 32,xdim0,ydim0,xdim1,ydim1,xdim2,ydim2,xdim3,ydim3,xdim4,ydim4,xdim5,ydim5,xdim6,ydim6,xdim7,ydim7,xdim8,ydim8,xdim9,ydim9,xdim10,ydim10,xdim11,ydim11);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -187,18 +187,6 @@ void ops_par_loop_viscosity_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
-  int dat9 = args[9].dat->elem_size;
-  int dat10 = args[10].dat->elem_size;
-  int dat11 = args[11].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/CloverLeaf_3D_HDF5/generate.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/generate.cpp
@@ -51,5 +51,4 @@ void generate()
     ops_fetch_dat_hdf5_file(xvel0, "test_cloverdata.h5");
     ops_fetch_dat_hdf5_file(yvel0, "test_cloverdata.h5");
     ops_fetch_dat_hdf5_file(zvel0, "test_cloverdata.h5");
-
 }

--- a/apps/c/CloverLeaf_3D_HDF5/generate_ops.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/generate_ops.cpp
@@ -30,5 +30,4 @@ void generate()
     ops_fetch_dat_hdf5_file(xvel0, "test_cloverdata.h5");
     ops_fetch_dat_hdf5_file(yvel0, "test_cloverdata.h5");
     ops_fetch_dat_hdf5_file(zvel0, "test_cloverdata.h5");
-
 }

--- a/apps/c/CloverLeaf_3D_HDF5/test.sh
+++ b/apps/c/CloverLeaf_3D_HDF5/test.sh
@@ -82,7 +82,7 @@ rm perf_out
 
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make cuda
 make mpi_cuda
 cd -

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/Riemann_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/Riemann_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_Riemann_kernel(int xdim0, int xdim1, int xdim2, int xdim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/Riemann_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/Riemann_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_Riemann_kernel(int xdim0, int xdim1, int xdim2, int xdim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_Riemann_kernel=%d  -Dxdim1_Riemann_kernel=%d  -Dxdim2_Riemann_kernel=%d  -Dxdim3_Riemann_kernel=%d  -Dxdim4_Riemann_kernel=%d  -Dxdim5_Riemann_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,12 +166,6 @@ void ops_par_loop_Riemann_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/calupwindeff_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/calupwindeff_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calupwindeff_kernel(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calupwindeff_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calupwindeff_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calupwindeff_kernel(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calupwindeff_kernel=%d  -Dxdim1_calupwindeff_kernel=%d  -Dxdim2_calupwindeff_kernel=%d  -Dxdim3_calupwindeff_kernel=%d  -Dxdim4_calupwindeff_kernel=%d  -Dxdim5_calupwindeff_kernel=%d  -Dxdim6_calupwindeff_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -167,13 +167,6 @@ void ops_par_loop_calupwindeff_kernel(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/calvar_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/calvar_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calvar_kernel(int xdim0, int xdim1, int xdim2, int xdim3
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calvar_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calvar_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calvar_kernel(int xdim0, int xdim1, int xdim2, int xdim3
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calvar_kernel=%d  -Dxdim1_calvar_kernel=%d  -Dxdim2_calvar_kernel=%d  -Dxdim3_calvar_kernel=%d  -Dxdim4_calvar_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,11 +165,6 @@ void ops_par_loop_calvar_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/checkop_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/checkop_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_checkop_kernel(int xdim0, int xdim1, int xdim2) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/checkop_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/checkop_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_checkop_kernel(int xdim0, int xdim1, int xdim2) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_checkop_kernel=%d  -Dxdim1_checkop_kernel=%d  -Dxdim2_checkop_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -210,9 +210,6 @@ void ops_par_loop_checkop_kernel(char const *name, ops_block block, int dim, int
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/fact_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/fact_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_fact_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/fact_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/fact_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_fact_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_fact_kernel=%d  -Dxdim1_fact_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_fact_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/gridgen_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/gridgen_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_gridgen_kernel(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/gridgen_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/gridgen_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_gridgen_kernel(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_gridgen_kernel=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,7 +166,6 @@ void ops_par_loop_gridgen_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/init_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/init_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_init_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/init_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/init_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_init_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_init_kernel=%d  -Dxdim1_init_kernel=%d  -Dxdim2_init_kernel=%d  -Dxdim3_init_kernel=%d  -Dxdim4_init_kernel=%d  -Dxdim5_init_kernel=%d  -Dxdim6_init_kernel=%d  -Dxdim7_init_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -168,14 +168,6 @@ void ops_par_loop_init_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/limiter_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/limiter_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_limiter_kernel(int xdim0, int xdim1, int xdim2) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/limiter_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/limiter_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_limiter_kernel(int xdim0, int xdim1, int xdim2) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_limiter_kernel=%d  -Dxdim1_limiter_kernel=%d  -Dxdim2_limiter_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,9 +162,6 @@ void ops_par_loop_limiter_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/residue_eval_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/residue_eval_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_residue_eval(int xdim0, int xdim1, int xdim2, int xdim3,
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/residue_eval.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/residue_eval.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_residue_eval(int xdim0, int xdim1, int xdim2, int xdim3,
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_residue_eval=%d  -Dxdim1_residue_eval=%d  -Dxdim2_residue_eval=%d  -Dxdim3_residue_eval=%d  -Dxdim4_residue_eval=%d  -Dxdim5_residue_eval=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,12 +166,6 @@ void ops_par_loop_residue_eval(char const *name, ops_block block, int dim, int* 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/save_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/save_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_save_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/save_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/save_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_save_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_save_kernel=%d  -Dxdim1_save_kernel=%d  -Dxdim2_save_kernel=%d  -Dxdim3_save_kernel=%d  -Dxdim4_save_kernel=%d  -Dxdim5_save_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,12 +166,6 @@ void ops_par_loop_save_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/tvd_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/tvd_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_tvd_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/tvd_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/tvd_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_tvd_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_tvd_kernel=%d  -Dxdim1_tvd_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_tvd_kernel(char const *name, ops_block block, int dim, int* ra
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/updateRK3_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/updateRK3_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_updateRK3_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/updateRK3_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/updateRK3_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_updateRK3_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_updateRK3_kernel=%d  -Dxdim1_updateRK3_kernel=%d  -Dxdim2_updateRK3_kernel=%d  -Dxdim3_updateRK3_kernel=%d  -Dxdim4_updateRK3_kernel=%d  -Dxdim5_updateRK3_kernel=%d  -Dxdim6_updateRK3_kernel=%d  -Dxdim7_updateRK3_kernel=%d  -Dxdim8_updateRK3_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -170,15 +170,6 @@ void ops_par_loop_updateRK3_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/update_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/update_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_kernel(int xdim0, int xdim1, int xdim2, int xdim3
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_kernel(int xdim0, int xdim1, int xdim2, int xdim3
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_kernel=%d  -Dxdim1_update_kernel=%d  -Dxdim2_update_kernel=%d  -Dxdim3_update_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -163,10 +163,6 @@ void ops_par_loop_update_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/vars_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/vars_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_vars_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/vars_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/vars_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_vars_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_vars_kernel=%d  -Dxdim1_vars_kernel=%d  -Dxdim2_vars_kernel=%d  -Dxdim3_vars_kernel=%d  -Dxdim4_vars_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,11 +165,6 @@ void ops_par_loop_vars_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/OpenCL/xder1_kernel_opencl_kernel.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/OpenCL/xder1_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_xder1_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/xder1_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/xder1_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_xder1_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_xder1_kernel=%d  -Dxdim1_xder1_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_xder1_kernel(char const *name, ops_block block, int dim, int* 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/mb_shsgc/Max_datatransfer/test.sh
+++ b/apps/c/mb_shsgc/Max_datatransfer/test.sh
@@ -88,7 +88,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -176,7 +176,7 @@ grep "Post shock Error is" perf_out
 grep "Total Wall time" perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -

--- a/apps/c/multiDim/OpenCL/multidim_copy_kernel_opencl_kernel.cpp
+++ b/apps/c/multiDim/OpenCL/multidim_copy_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_multidim_copy_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/multidim_copy_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/multidim_copy_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_multidim_copy_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_multidim_copy_kernel=%d  -Dxdim1_multidim_copy_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,8 +162,6 @@ void ops_par_loop_multidim_copy_kernel(char const *name, ops_block block, int di
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/multiDim/OpenCL/multidim_kernel_opencl_kernel.cpp
+++ b/apps/c/multiDim/OpenCL/multidim_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_multidim_kernel(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/multidim_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/multidim_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_multidim_kernel(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_multidim_kernel=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -169,7 +169,6 @@ void ops_par_loop_multidim_kernel(char const *name, ops_block block, int dim, in
 
 
 
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/multiDim/OpenCL/multidim_reduce_kernel_opencl_kernel.cpp
+++ b/apps/c/multiDim/OpenCL/multidim_reduce_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_multidim_reduce_kernel(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/multidim_reduce_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/multidim_reduce_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_multidim_reduce_kernel(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_multidim_reduce_kernel=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -182,7 +182,6 @@ void ops_par_loop_multidim_reduce_kernel(char const *name, ops_block block, int 
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/multiDim/test.sh
+++ b/apps/c/multiDim/test.sh
@@ -67,7 +67,7 @@ rm perf_out
 
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -133,7 +133,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make cuda
 make mpi_cuda

--- a/apps/c/poisson/OpenCL/poisson_kernel_error_opencl_kernel.cpp
+++ b/apps/c/poisson/OpenCL/poisson_kernel_error_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_poisson_kernel_error(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/poisson_kernel_error.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/poisson_kernel_error.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_poisson_kernel_error(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_poisson_kernel_error=%d  -Dxdim1_poisson_kernel_error=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -183,8 +183,6 @@ void ops_par_loop_poisson_kernel_error(char const *name, ops_block block, int di
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/poisson/OpenCL/poisson_kernel_initialguess_opencl_kernel.cpp
+++ b/apps/c/poisson/OpenCL/poisson_kernel_initialguess_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_poisson_kernel_initialguess(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/poisson_kernel_initialguess.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/poisson_kernel_initialguess.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_poisson_kernel_initialguess(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_poisson_kernel_initialguess=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,7 +161,6 @@ void ops_par_loop_poisson_kernel_initialguess(char const *name, ops_block block,
 
 
 
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/poisson/OpenCL/poisson_kernel_populate_opencl_kernel.cpp
+++ b/apps/c/poisson/OpenCL/poisson_kernel_populate_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_poisson_kernel_populate(int xdim3, int xdim4, int xdim5)
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/poisson_kernel_populate.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/poisson_kernel_populate.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_poisson_kernel_populate(int xdim3, int xdim4, int xdim5)
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim3_poisson_kernel_populate=%d  -Dxdim4_poisson_kernel_populate=%d  -Dxdim5_poisson_kernel_populate=%d ", pPath, 32,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -172,9 +172,6 @@ void ops_par_loop_poisson_kernel_populate(char const *name, ops_block block, int
 
 
 
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/poisson/OpenCL/poisson_kernel_stencil_opencl_kernel.cpp
+++ b/apps/c/poisson/OpenCL/poisson_kernel_stencil_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_poisson_kernel_stencil(int xdim0, int xdim1, int xdim2) 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/poisson_kernel_stencil.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/poisson_kernel_stencil.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_poisson_kernel_stencil(int xdim0, int xdim1, int xdim2) 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_poisson_kernel_stencil=%d  -Dxdim1_poisson_kernel_stencil=%d  -Dxdim2_poisson_kernel_stencil=%d ", pPath, 32,xdim0,xdim1,xdim2);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -163,9 +163,6 @@ void ops_par_loop_poisson_kernel_stencil(char const *name, ops_block block, int 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/poisson/OpenCL/poisson_kernel_update_opencl_kernel.cpp
+++ b/apps/c/poisson/OpenCL/poisson_kernel_update_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_poisson_kernel_update(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/poisson_kernel_update.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/poisson_kernel_update.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_poisson_kernel_update(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_poisson_kernel_update=%d  -Dxdim1_poisson_kernel_update=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,8 +162,6 @@ void ops_par_loop_poisson_kernel_update(char const *name, ops_block block, int d
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/poisson/test.sh
+++ b/apps/c/poisson/test.sh
@@ -66,7 +66,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -133,7 +133,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make cuda
 make mpi_cuda

--- a/apps/c/shsgc/OpenCL/Riemann_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/Riemann_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_Riemann_kernel(int xdim0, int xdim1, int xdim2, int xdim
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/Riemann_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/Riemann_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_Riemann_kernel(int xdim0, int xdim1, int xdim2, int xdim
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_Riemann_kernel=%d  -Dxdim1_Riemann_kernel=%d  -Dxdim2_Riemann_kernel=%d  -Dxdim3_Riemann_kernel=%d  -Dxdim4_Riemann_kernel=%d  -Dxdim5_Riemann_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,12 +166,6 @@ void ops_par_loop_Riemann_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/calupwindeff_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/calupwindeff_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_calupwindeff_kernel(int xdim0, int xdim1, int xdim2, int
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/calupwindeff_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/calupwindeff_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_calupwindeff_kernel(int xdim0, int xdim1, int xdim2, int
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_calupwindeff_kernel=%d  -Dxdim1_calupwindeff_kernel=%d  -Dxdim2_calupwindeff_kernel=%d  -Dxdim3_calupwindeff_kernel=%d  -Dxdim4_calupwindeff_kernel=%d  -Dxdim5_calupwindeff_kernel=%d  -Dxdim6_calupwindeff_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -167,13 +167,6 @@ void ops_par_loop_calupwindeff_kernel(char const *name, ops_block block, int dim
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/drhoEpudx_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/drhoEpudx_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_drhoEpudx_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/drhoEpudx_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/drhoEpudx_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_drhoEpudx_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_drhoEpudx_kernel=%d  -Dxdim1_drhoEpudx_kernel=%d  -Dxdim2_drhoEpudx_kernel=%d  -Dxdim3_drhoEpudx_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -163,10 +163,6 @@ void ops_par_loop_drhoEpudx_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/drhoudx_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/drhoudx_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_drhoudx_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/drhoudx_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/drhoudx_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_drhoudx_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_drhoudx_kernel=%d  -Dxdim1_drhoudx_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_drhoudx_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/drhouupdx_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/drhouupdx_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_drhouupdx_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/drhouupdx_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/drhouupdx_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_drhouupdx_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_drhouupdx_kernel=%d  -Dxdim1_drhouupdx_kernel=%d  -Dxdim2_drhouupdx_kernel=%d  -Dxdim3_drhouupdx_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -163,10 +163,6 @@ void ops_par_loop_drhouupdx_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/fact_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/fact_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_fact_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/fact_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/fact_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_fact_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_fact_kernel=%d  -Dxdim1_fact_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_fact_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/initialize_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/initialize_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_initialize_kernel(int xdim0, int xdim1, int xdim2, int x
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/initialize_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/initialize_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_initialize_kernel(int xdim0, int xdim1, int xdim2, int x
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_initialize_kernel=%d  -Dxdim1_initialize_kernel=%d  -Dxdim2_initialize_kernel=%d  -Dxdim3_initialize_kernel=%d  -Dxdim4_initialize_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -171,11 +171,6 @@ void ops_par_loop_initialize_kernel(char const *name, ops_block block, int dim, 
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/limiter_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/limiter_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_limiter_kernel(int xdim0, int xdim1, int xdim2) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/limiter_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/limiter_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_limiter_kernel(int xdim0, int xdim1, int xdim2) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_limiter_kernel=%d  -Dxdim1_limiter_kernel=%d  -Dxdim2_limiter_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,9 +162,6 @@ void ops_par_loop_limiter_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/save_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/save_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_save_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/save_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/save_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_save_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_save_kernel=%d  -Dxdim1_save_kernel=%d  -Dxdim2_save_kernel=%d  -Dxdim3_save_kernel=%d  -Dxdim4_save_kernel=%d  -Dxdim5_save_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -166,12 +166,6 @@ void ops_par_loop_save_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/test_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/test_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_test_kernel(int xdim0) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/test_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/test_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_test_kernel(int xdim0) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_test_kernel=%d ", pPath, 32,xdim0);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -181,7 +181,6 @@ void ops_par_loop_test_kernel(char const *name, ops_block block, int dim, int* r
 
 
   mvReductArraysToDevice(reduct_bytes);
-  int dat0 = args[0].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/tvd_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/tvd_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_tvd_kernel(int xdim0, int xdim1) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/tvd_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/tvd_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_tvd_kernel(int xdim0, int xdim1) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_tvd_kernel=%d  -Dxdim1_tvd_kernel=%d ", pPath, 32,xdim0,xdim1);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -161,8 +161,6 @@ void ops_par_loop_tvd_kernel(char const *name, ops_block block, int dim, int* ra
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/updateRK3_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/updateRK3_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_updateRK3_kernel(int xdim0, int xdim1, int xdim2, int xd
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/updateRK3_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/updateRK3_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_updateRK3_kernel(int xdim0, int xdim1, int xdim2, int xd
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_updateRK3_kernel=%d  -Dxdim1_updateRK3_kernel=%d  -Dxdim2_updateRK3_kernel=%d  -Dxdim3_updateRK3_kernel=%d  -Dxdim4_updateRK3_kernel=%d  -Dxdim5_updateRK3_kernel=%d  -Dxdim6_updateRK3_kernel=%d  -Dxdim7_updateRK3_kernel=%d  -Dxdim8_updateRK3_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4,xdim5,xdim6,xdim7,xdim8);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -170,15 +170,6 @@ void ops_par_loop_updateRK3_kernel(char const *name, ops_block block, int dim, i
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
-  int dat5 = args[5].dat->elem_size;
-  int dat6 = args[6].dat->elem_size;
-  int dat7 = args[7].dat->elem_size;
-  int dat8 = args[8].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/update_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/update_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_update_kernel(int xdim0, int xdim1, int xdim2, int xdim3
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/update_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/update_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_update_kernel(int xdim0, int xdim1, int xdim2, int xdim3
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_update_kernel=%d  -Dxdim1_update_kernel=%d  -Dxdim2_update_kernel=%d  -Dxdim3_update_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -163,10 +163,6 @@ void ops_par_loop_update_kernel(char const *name, ops_block block, int dim, int*
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/vars_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/vars_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_vars_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/vars_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/vars_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_vars_kernel(int xdim0, int xdim1, int xdim2, int xdim3, 
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_vars_kernel=%d  -Dxdim1_vars_kernel=%d  -Dxdim2_vars_kernel=%d  -Dxdim3_vars_kernel=%d  -Dxdim4_vars_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2,xdim3,xdim4);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -165,11 +165,6 @@ void ops_par_loop_vars_kernel(char const *name, ops_block block, int dim, int* r
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
-  int dat3 = args[3].dat->elem_size;
-  int dat4 = args[4].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/OpenCL/zerores_kernel_opencl_kernel.cpp
+++ b/apps/c/shsgc/OpenCL/zerores_kernel_opencl_kernel.cpp
@@ -18,7 +18,7 @@ void buildOpenCLKernels_zerores_kernel(int xdim0, int xdim1, int xdim2) {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"./OpenCL/zerores_kernel.cl"};
+    char* source_filename[1] = {(char*)"./OpenCL/zerores_kernel.cl"};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -62,7 +62,7 @@ void buildOpenCLKernels_zerores_kernel(int xdim0, int xdim1, int xdim2) {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d  -Dxdim0_zerores_kernel=%d  -Dxdim1_zerores_kernel=%d  -Dxdim2_zerores_kernel=%d ", pPath, 32,xdim0,xdim1,xdim2);
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -162,9 +162,6 @@ void ops_par_loop_zerores_kernel(char const *name, ops_block block, int dim, int
 
 
 
-  int dat0 = args[0].dat->elem_size;
-  int dat1 = args[1].dat->elem_size;
-  int dat2 = args[2].dat->elem_size;
 
   //set up initial pointers
   int d_m[OPS_MAX_DIM];

--- a/apps/c/shsgc/test.sh
+++ b/apps/c/shsgc/test.sh
@@ -67,7 +67,7 @@ rm perf_out
 
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -
@@ -134,7 +134,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd -
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make clean
 make
 cd -

--- a/apps/fortran/multiDim/test.sh
+++ b/apps/fortran/multiDim/test.sh
@@ -24,7 +24,7 @@ rm perf_out
 
 
 cd $OPS_INSTALL_PATH/fortran
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make
 cd -
 make

--- a/apps/fortran/poisson/test.sh
+++ b/apps/fortran/poisson/test.sh
@@ -23,7 +23,7 @@ grep "Total Wall time" perf_out
 rm perf_out
 
 cd $OPS_INSTALL_PATH/fortran
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make
 cd -
 make

--- a/apps/fortran/shsgc/test.sh
+++ b/apps/fortran/shsgc/test.sh
@@ -26,7 +26,7 @@ rm perf_out
 
 
 cd $OPS_INSTALL_PATH/fortran
-source ../source_pgi_15.1
+source ../source_pgi_15.10
 make
 cd -
 make clean

--- a/ops/c/src/externlib/ops_hdf5.c
+++ b/ops/c/src/externlib/ops_hdf5.c
@@ -256,6 +256,20 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
   //make sure we multiply by the number of data values per element (i.e. dat->dim)
   g_size[1] = g_size[1]*dat->dim;
 
+  hsize_t G_SIZE[block->dims];
+  if(block->dims == 1) {
+    G_SIZE[0] = g_size[0];
+  }
+  else if(block->dims == 2) {
+    G_SIZE[0] = g_size[1];
+    G_SIZE[1] = g_size[0];
+  }
+  else if(block->dims == 3){
+    G_SIZE[0] = g_size[2];
+    G_SIZE[1] = g_size[1];
+    G_SIZE[2] = g_size[0];
+  }
+
   //Set up file access property list with parallel I/O access
   plist_id = H5Pcreate(H5P_FILE_ACCESS);
 
@@ -285,19 +299,19 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
         dat->name, block->name);
 
 	  if(strcmp(dat->type,"double") == 0 || strcmp(dat->type,"real(8)") == 0)
-        H5LTmake_dataset(group_id,dat->name,block->dims,g_size,H5T_NATIVE_DOUBLE,dat->data);
+        H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_DOUBLE,dat->data);
       else if(strcmp(dat->type,"float") == 0 || strcmp(dat->type,"real(4)") || strcmp(dat->type,"real") == 0)
-        H5LTmake_dataset(group_id,dat->name,block->dims,g_size,H5T_NATIVE_FLOAT,dat->data);
+        H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_FLOAT,dat->data);
       else if(strcmp(dat->type,"int") == 0 || strcmp(dat->type,"int(4)")  || strcmp(dat->type,"integer(4)") == 0)
-         H5LTmake_dataset(group_id,dat->name,block->dims,g_size,H5T_NATIVE_INT,dat->data);
+         H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_INT,dat->data);
       else if(strcmp(dat->type,"long") == 0)
-         H5LTmake_dataset(group_id,dat->name,block->dims,g_size,H5T_NATIVE_LONG,dat->data);
+         H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_LONG,dat->data);
       else if(strcmp(dat->type,"long long") == 0)
-         H5LTmake_dataset(group_id,dat->name,block->dims,g_size,H5T_NATIVE_LLONG,dat->data);
-      else {
-		printf("Unknown type in ops_fetch_dat_hdf5_file()\n");
-		exit(-2);
-      }
+         H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_LLONG,dat->data);
+    else {
+		  printf("Unknown type in ops_fetch_dat_hdf5_file()\n");
+		  exit(-2);
+    }
 
 	  //attach attributes to dat
 	  H5LTset_attribute_string(group_id, dat->name, "ops_type", "ops_dat"); //ops type
@@ -308,8 +322,8 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 	  H5LTset_attribute_int(group_id, dat->name, "d_m", dat->d_m, block->dims); //d_m
 	  H5LTset_attribute_int(group_id, dat->name, "d_p", dat->d_p, block->dims); //d_p
 	  H5LTset_attribute_int(group_id, dat->name, "base", dat->base, block->dims); //base
-      H5LTset_attribute_string(group_id, dat->name, "type", dat->type); //type
-    }
+    H5LTset_attribute_string(group_id, dat->name, "type", dat->type); //type
+  }
 
 	H5Gclose(group_id);
 	H5Fclose(file_id);

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -586,6 +586,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
         ops_printf("ops_fetch_dat_hdf5_file: ops_dat %s does not exists in the ops_block %s ... creating ops_dat\n",
           dat->name, block->name);
 
+        //transpose global size as on hdf5 file the dims are written transposed
         hsize_t GBL_SIZE[block->dims];
         if(block->dims == 1) {
           GBL_SIZE[0] = gbl_size[0];
@@ -1386,9 +1387,23 @@ void ops_read_dat_hdf5(ops_dat dat) {
 
     dset_id = H5Dopen(group_id, dat->name, H5P_DEFAULT);
 
+    hsize_t GBL_SIZE[block->dims];
+    if(block->dims == 1) {
+      GBL_SIZE[0] = gbl_size[0];
+    }
+    else if(block->dims == 2) {
+      GBL_SIZE[0] = gbl_size[1];
+      GBL_SIZE[1] = gbl_size[0];
+    }
+    else if(block->dims == 3){
+      GBL_SIZE[0] = gbl_size[2];
+      GBL_SIZE[1] = gbl_size[1];
+      GBL_SIZE[2] = gbl_size[0];
+    }
+
     // Create chunked dataset
     plist_id = H5Pcreate(H5P_DATASET_CREATE);
-    H5Pset_chunk(plist_id, block->dims, gbl_size); //chunk data set need to be the same size on each proc
+    H5Pset_chunk(plist_id, block->dims, GBL_SIZE); //chunk data set need to be the same size on each proc
     H5Pclose(plist_id);
 
     //Need to flip the dimensions to accurately read from HDF5 chunk decomposition

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -586,12 +586,26 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
         ops_printf("ops_fetch_dat_hdf5_file: ops_dat %s does not exists in the ops_block %s ... creating ops_dat\n",
           dat->name, block->name);
 
+        hsize_t GBL_SIZE[block->dims];
+        if(block->dims == 1) {
+          GBL_SIZE[0] = gbl_size[0];
+        }
+        else if(block->dims == 2) {
+          GBL_SIZE[0] = gbl_size[1];
+          GBL_SIZE[1] = gbl_size[0];
+        }
+        else if(block->dims == 3){
+          GBL_SIZE[0] = gbl_size[2];
+          GBL_SIZE[1] = gbl_size[1];
+          GBL_SIZE[2] = gbl_size[0];
+        }
+
         //Create the dataspace for the dataset
-        filespace = H5Screate_simple(block->dims, gbl_size, NULL); //space in file
+        filespace = H5Screate_simple(block->dims, GBL_SIZE, NULL); //space in file
 
         // Create chunked dataset
         plist_id = H5Pcreate(H5P_DATASET_CREATE);
-        H5Pset_chunk(plist_id, block->dims, gbl_size); //chunk data set need to be the same size on each proc
+        H5Pset_chunk(plist_id, block->dims, GBL_SIZE); //chunk data set need to be the same size on each proc
 
         //Create the dataset with default properties and close filespace.
         if(strcmp(dat->type,"double") == 0 ||

--- a/ops/c/src/mpi/ops_mpi_rt_support_opencl.cpp
+++ b/ops/c/src/mpi/ops_mpi_rt_support_opencl.cpp
@@ -211,7 +211,7 @@ void ops_pack(ops_dat dat, const int src_offset, char *__restrict dest, const op
     printf("in packer4 build\n");
   }
 
-  const char * __restrict src = dat->data_d+src_offset*dat->elem_size;
+  //const char * __restrict src = dat->data_d+src_offset*dat->elem_size;
 
   if (halo_buffer_size < halo->count*halo->blocklength) {
     if (halo_buffer_d != NULL) clSafeCall( clReleaseMemObject(halo_buffer_d));
@@ -353,7 +353,7 @@ void ops_unpack(ops_dat dat, const int dest_offset, const char *__restrict src, 
 			isbuilt_unpacker4_kernel = true;
 		}
 
-  char * __restrict dest = dat->data_d+dest_offset*dat->elem_size;
+  //char * __restrict dest = dat->data_d+dest_offset*dat->elem_size;
 
   if (halo_buffer_size < halo->count*halo->blocklength) {
     if (halo_buffer_d!=NULL) clSafeCall( clReleaseMemObject(halo_buffer_d));

--- a/ops/test_all.sh
+++ b/ops/test_all.sh
@@ -9,14 +9,14 @@ cd $OPS_INSTALL_PATH
 echo "************Testing C Applications *****************"
 cd ../apps/c/CloverLeaf/
 cd ../CloverLeaf/
-#./generate.sh
-#./test.sh
-#cd ../CloverLeaf_3D/
-#./generate.sh
-#./test.sh
-#cd ../CloverLeaf_3D_HDF5/
-#./generate.sh
-#./test.sh
+./generate.sh
+./test.sh
+cd ../CloverLeaf_3D/
+./generate.sh
+./test.sh
+cd ../CloverLeaf_3D_HDF5/
+./generate.sh
+./test.sh
 cd ../poisson/
 ../../../translator/python/c/ops.py poisson.cpp
 ./test.sh

--- a/translator/python/c/ops_gen_mpi_opencl.py
+++ b/translator/python/c/ops_gen_mpi_opencl.py
@@ -544,7 +544,7 @@ void buildOpenCLKernels_"""+kernel_name_list[nk]+"""("""+arg_text+""") {
     buildOpenCLKernels();
     //clSafeCall( clUnloadCompiler() );
     cl_int ret;
-    char* source_filename[1] = {"""+kernel_list_text+"""};
+    char* source_filename[1] = {(char*)"""+kernel_list_text+"""};
 
     // Load the kernel source code into the array source_str
     FILE *fid;
@@ -588,7 +588,7 @@ void buildOpenCLKernels_"""+kernel_name_list[nk]+"""("""+arg_text+""") {
         else
           sprintf(buildOpts,"-cl-mad-enable -I%s/c/include -DOPS_WARPSIZE=%d """+compile_line+""", pPath, 32,"""+arg_values+""");
       else {
-        sprintf("Incorrect OPS_INSTALL_PATH %s\\n",pPath);
+        sprintf((char*)"Incorrect OPS_INSTALL_PATH %s\\n",pPath);
         exit(EXIT_FAILURE);
       }
 
@@ -868,9 +868,9 @@ void buildOpenCLKernels_"""+kernel_name_list[nk]+"""("""+arg_text+""") {
 
 
     #set up initial pointers
-    for n in range (0, nargs):
-      if arg_typ[n] == 'ops_arg_dat':
-        code('int dat'+str(n)+' = args['+str(n)+'].dat->elem_size;')
+    #for n in range (0, nargs):
+    #  if arg_typ[n] == 'ops_arg_dat':
+    #    code('int dat'+str(n)+' = args['+str(n)+'].dat->elem_size;')
 
 
     comm('')


### PR DESCRIPTION
Fixes bug that occurred when an asymmetric structured block is written and read from an HDF5 file. (Additionally some minor clean up has been done to get rid of the many warnings that occur when compiling with the PGI compiler.)