### PR TITLE
Fix/fortran rutime flags

### DIFF
--- a/apps/c/CloverLeaf_3D/Makefile
+++ b/apps/c/CloverLeaf_3D/Makefile
@@ -63,7 +63,7 @@ ifdef DEBUG
   CCFLAGS 	= -O2 -g -Minline -Kieee -Minform=inform -Minfo=all
 else
   #CCFLAGS 	= -O2 -Kieee -fastsse -gopt -Mipa=fast -Mlist -Minline #-Minform=severe -Minfo=all
-  CCFLAGS 	= -fastsse -gopt -Mipa=fast -Mlist -mp=nonuma -Kieee
+  CCFLAGS 	= -fastsse -gopt -Mipa=fast -mp=nonuma -Kieee
 endif
   CPPFLAGS 	= $(CCFLAGS) -ldl
   OMPFLAGS 	= -mp

--- a/apps/fortran/shsgc/shsgc_ops.F90
+++ b/apps/fortran/shsgc/shsgc_ops.F90
@@ -184,7 +184,7 @@ program SHSGC
 
 
 
-  niter = 1!9005
+  niter = 9005
   DO iter = 1, niter
 
     call save_kernel_host("save_kernel", shsgc_grid, 1, nxp_range, &

--- a/apps/fortran/shsgc/shsgc_ops.F90
+++ b/apps/fortran/shsgc/shsgc_ops.F90
@@ -184,7 +184,7 @@ program SHSGC
 
 
 
-  niter = 9005
+  niter = 1!9005
   DO iter = 1, niter
 
     call save_kernel_host("save_kernel", shsgc_grid, 1, nxp_range, &

--- a/ops/c/Makefile
+++ b/ops/c/Makefile
@@ -76,7 +76,7 @@ ifdef DEBUG
   CCFLAGS 	:= -O0 -g
 else
 #  CCFLAGS 	:= -O3
-  CCFLAGS 	:= -fastsse -gopt -Mipa=fast -Mlist #-mp=nonuma -Kieee
+  CCFLAGS 	:= -fastsse -gopt -Mipa=fast #-Mlist #-mp=nonuma -Kieee
 endif
   CUDA_ALIGNE_FLAG := -D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=
   CXX 		:= pgc++

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -123,27 +123,50 @@ void ops_set_args(int argc, char *argv) {
   char* pch;
   pch = strstr(argv, "OPS_BLOCK_SIZE_X=");
   if(pch != NULL) {
-    strncpy (temp,pch,63);
+    strncpy (temp,pch,20);
     OPS_block_size_x = atoi ( temp + 17 );
     ops_printf ( "\n OPS_block_size_x = %d \n", OPS_block_size_x );
   }
   pch = strstr(argv, "OPS_BLOCK_SIZE_Y=");
   if(pch != NULL) {
-    strncpy (temp,pch,63);
+    strncpy (temp,pch,20);
     OPS_block_size_y = atoi ( temp + 17 );
     ops_printf ( "\n OPS_block_size_y = %d \n", OPS_block_size_y );
   }
   pch = strstr(argv, "-gpudirect");
   if(pch != NULL) {
-    strncpy (temp,pch,63);
     OPS_gpu_direct = 1;
     ops_printf ( "\n GPU Direct enabled\n" );
   }
   pch = strstr(argv, "-OPS_DIAGS=");
   if(pch != NULL) {
-    strncpy (temp,pch,63);
-    OPS_diags = atoi ( temp + 10 );
+    strncpy (temp,pch,12);
+    OPS_diags = atoi ( temp + 11 );
     ops_printf ( "\n OPS_diags = %d \n", OPS_diags  );
+  }
+
+  if(strstr(argv, "OPS_CHECKPOINT_INMEMORY") != NULL) {
+    ops_checkpoint_inmemory = 1;
+    ops_printf ( "\n OPS Checkpointing in memory\n");
+  }
+  else if(strstr(argv, "OPS_CHECKPOINT_LOCKFILE") != NULL) {
+    ops_lock_file = 1;
+    ops_printf ( "\n OPS Checkpointing creating lockfiles\n");
+  }
+  else if(strstr(argv, "OPS_CHECKPOINT_THREAD") != NULL) {
+    ops_thread_offload = 1;
+    ops_printf ( "\n OPS Checkpointing on a separate thread\n");
+  }
+  else if(strstr(argv, "OPS_CHECKPOINT=") != NULL) {
+    pch = strstr(argv, "OPS_CHECKPOINT=");
+    OPS_enable_checkpointing = 2;
+    strncpy (temp,pch,20);
+    OPS_ranks_per_node = atoi ( temp+ 15 );
+    ops_printf ( "\n OPS Checkpointing with mirroring offset %d\n", OPS_ranks_per_node);
+  }
+  else if (strstr(argv, "OPS_CHECKPOINT") != NULL) {
+      OPS_enable_checkpointing = 1;
+      ops_printf ( "\n OPS Checkpointing enabled\n");
   }
 }
 
@@ -156,7 +179,9 @@ void ops_init_core( int argc, char ** argv, int diags )
 
   for ( int n = 1; n < argc; n++ ) {
 
-    if ( strncmp ( argv[n], "OPS_BLOCK_SIZE_X=", 17 ) == 0 )
+    ops_set_args(argc, argv[n]);
+
+    /*if ( strncmp ( argv[n], "OPS_BLOCK_SIZE_X=", 17 ) == 0 )
     {
       OPS_block_size_x = atoi ( argv[n] + 17 );
       ops_printf ( "\n OPS_block_size_x = %d \n", OPS_block_size_x );
@@ -203,7 +228,7 @@ void ops_init_core( int argc, char ** argv, int diags )
     {
       OPS_enable_checkpointing = 1;
       ops_printf ( "\n OPS Checkpointing enabled\n");
-    }
+    }*/
 
   }
 

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -117,7 +117,7 @@ ops_dat search_dat(ops_block block, int elem_size, int *dat_size, int* offset,
 commandline arguments as argv is not easy to pass through from
 frotran to C
 */
-void ops_set_args( int argc, char * argv) {
+void ops_set_args(int argc, char *argv) {
 
   char temp[64];
   char* pch;
@@ -136,13 +136,13 @@ void ops_set_args( int argc, char * argv) {
   pch = strstr(argv, "-gpudirect");
   if(pch != NULL) {
     strncpy (temp,pch,63);
-    OPS_block_size_y = atoi ( temp + 10 );
+    OPS_gpu_direct = 1;
     ops_printf ( "\n GPU Direct enabled\n" );
   }
   pch = strstr(argv, "-OPS_DIAGS=");
   if(pch != NULL) {
     strncpy (temp,pch,63);
-    OPS_block_size_y = atoi ( temp + 10 );
+    OPS_diags = atoi ( temp + 10 );
     ops_printf ( "\n OPS_diags = %d \n", OPS_diags  );
   }
 }

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -113,6 +113,40 @@ ops_dat search_dat(ops_block block, int elem_size, int *dat_size, int* offset,
   return NULL;
 }
 
+/* Special function only called by fortran backend to get
+commandline arguments as argv is not easy to pass through from
+frotran to C
+*/
+void ops_set_args( int argc, char * argv) {
+
+  char temp[64];
+  char* pch;
+  pch = strstr(argv, "OPS_BLOCK_SIZE_X=");
+  if(pch != NULL) {
+    strncpy (temp,pch,63);
+    OPS_block_size_x = atoi ( temp + 17 );
+    ops_printf ( "\n OPS_block_size_x = %d \n", OPS_block_size_x );
+  }
+  pch = strstr(argv, "OPS_BLOCK_SIZE_Y=");
+  if(pch != NULL) {
+    strncpy (temp,pch,63);
+    OPS_block_size_y = atoi ( temp + 17 );
+    ops_printf ( "\n OPS_block_size_y = %d \n", OPS_block_size_y );
+  }
+  pch = strstr(argv, "-gpudirect");
+  if(pch != NULL) {
+    strncpy (temp,pch,63);
+    OPS_block_size_y = atoi ( temp + 10 );
+    ops_printf ( "\n GPU Direct enabled\n" );
+  }
+  pch = strstr(argv, "-OPS_DIAGS=");
+  if(pch != NULL) {
+    strncpy (temp,pch,63);
+    OPS_block_size_y = atoi ( temp + 10 );
+    ops_printf ( "\n OPS_diags = %d \n", OPS_diags  );
+  }
+}
+
 /*
 * OPS core functions
 */
@@ -120,8 +154,8 @@ void ops_init_core( int argc, char ** argv, int diags )
 {
   OPS_diags = diags;
 
-  for ( int n = 1; n < argc; n++ )
-  {
+  for ( int n = 1; n < argc; n++ ) {
+
     if ( strncmp ( argv[n], "OPS_BLOCK_SIZE_X=", 17 ) == 0 )
     {
       OPS_block_size_x = atoi ( argv[n] + 17 );

--- a/ops/fortran/src/ops_for_declarations.F90
+++ b/ops/fortran/src/ops_for_declarations.F90
@@ -465,9 +465,9 @@ module OPS_Fortran_Declarations
 
 
 
-    subroutine ops_exit ( )
-      call ops_exit_c (  )
-    end subroutine ops_exit
+  subroutine ops_exit ( )
+    call ops_exit_c (  )
+  end subroutine ops_exit
 
   subroutine ops_decl_block ( dims, block, name )
 

--- a/ops/fortran/src/ops_for_declarations.F90
+++ b/ops/fortran/src/ops_for_declarations.F90
@@ -185,11 +185,10 @@ module OPS_Fortran_Declarations
       integer(kind=c_int), intent(in), value :: diags
     end subroutine ops_init_c
 
-
     subroutine ops_set_args_c ( argc, argv ) BIND(C,name='ops_set_args')
       use, intrinsic :: ISO_C_BINDING
       integer(kind=c_int), intent(in), value :: argc
-      character(kind=c_char,len=64) :: argv
+      character(len=1, kind=C_CHAR) :: argv
     end subroutine ops_set_args_c
 
     subroutine ops_exit_c (  ) BIND(C,name='ops_exit')
@@ -448,15 +447,9 @@ module OPS_Fortran_Declarations
 
     subroutine ops_init ( diags )
       integer(4) :: diags
-      integer(4) :: argc = 0
+      integer(kind=c_int) :: argc
       integer :: i
       character(kind=c_char,len=64)           :: temp
-
-!#ifdef OPS_WITH_CUDAFOR
-!    integer(4) :: setDevReturnVal = -1
-!    integer(4) :: devPropRetVal = -1
-!    type(cudadeviceprop) :: deviceProperties
-!#endif
 
       !Get the command line arguments - needs to be handled using Fortrn
       argc = command_argument_count()
@@ -467,7 +460,6 @@ module OPS_Fortran_Declarations
       end do
 
       call ops_init_c (0, C_NULL_PTR, diags)
-
 
     end subroutine ops_init
 

--- a/ops/fortran/src/ops_for_declarations.F90
+++ b/ops/fortran/src/ops_for_declarations.F90
@@ -185,6 +185,13 @@ module OPS_Fortran_Declarations
       integer(kind=c_int), intent(in), value :: diags
     end subroutine ops_init_c
 
+
+    subroutine ops_set_args_c ( argc, argv ) BIND(C,name='ops_set_args')
+      use, intrinsic :: ISO_C_BINDING
+      integer(kind=c_int), intent(in), value :: argc
+      character(kind=c_char,len=64) :: argv
+    end subroutine ops_set_args_c
+
     subroutine ops_exit_c (  ) BIND(C,name='ops_exit')
       use, intrinsic :: ISO_C_BINDING
     end subroutine ops_exit_c
@@ -442,14 +449,29 @@ module OPS_Fortran_Declarations
     subroutine ops_init ( diags )
       integer(4) :: diags
       integer(4) :: argc = 0
+      integer :: i
+      character(kind=c_char,len=64)           :: temp
+
 !#ifdef OPS_WITH_CUDAFOR
 !    integer(4) :: setDevReturnVal = -1
 !    integer(4) :: devPropRetVal = -1
 !    type(cudadeviceprop) :: deviceProperties
 !#endif
 
-      call ops_init_c ( argc, C_NULL_PTR, diags )
+      !Get the command line arguments - needs to be handled using Fortrn
+      argc = command_argument_count()
+
+      do i = 1, argc
+        call get_command_argument(i, temp)
+        call ops_set_args_c (argc, temp) !special function to set args
+      end do
+
+      call ops_init_c (0, C_NULL_PTR, diags)
+
+
     end subroutine ops_init
+
+
 
     subroutine ops_exit ( )
       call ops_exit_c (  )


### PR DESCRIPTION
This pull request enables runtime arguments to be used within an OPS Fortran API based application. It relies on two Fortran 2003 intrinsic functions: command_argument_count() and get_command_argument()