### PR TITLE
Fix/fortran3d

### DIFF
--- a/apps/c/CloverLeaf/CUDA/generate_chunk_kernel_cuda_kernel.cu
+++ b/apps/c/CloverLeaf/CUDA/generate_chunk_kernel_cuda_kernel.cu
@@ -54,6 +54,8 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
                      const double *cellx, const double *celly) {
 
   double radius, x_cent, y_cent;
+  int is_in = 0;
+  int is_in2 = 0;
 
 
   energy0[OPS_ACC2(0,0)]= states[0].energy;
@@ -65,59 +67,74 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
 
     x_cent=states[i].xmin;
     y_cent=states[i].ymin;
+    is_in = 0;
+    is_in2 = 0;
 
     if (states[i].geometry == g_rect) {
-      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
-
-          energy0[OPS_ACC2(0,0)] = states[i].energy;
-          density0[OPS_ACC3(0,0)] = states[i].density;
-
-          xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
-          yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(1+i1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0)] < states[i].xmax) {
+            if(vertexy[OPS_ACC1(0,1+j1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1)] < states[i].ymax) {
+              is_in = 1;
+            }
+          }
         }
       }
-
-    }
-    else if(states[i].geometry == g_circ) {
-      radius = sqrt ((cellx[OPS_ACC6(0,0)] - x_cent) * (cellx[OPS_ACC6(0,0)] - x_cent) +
-                     (celly[OPS_ACC7(0,0)] - y_cent) * (celly[OPS_ACC7(0,0)] - y_cent));
-      if(radius <= states[i].radius) {
+      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
+          is_in2 = 1;
+        }
+      }
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
-
+      }
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      }
+    }
+    else if(states[i].geometry == g_circ) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          radius = sqrt ((cellx[OPS_ACC6(i1,0)] - x_cent) * (cellx[OPS_ACC6(i1,0)] - x_cent) +
+                     (celly[OPS_ACC7(0,j1)] - y_cent) * (celly[OPS_ACC7(0,j1)] - y_cent));
+          if (radius <= states[i].radius) {
+            is_in = 1;
+          }
+        }
+      }
+      if (radius <= states[i].radius) is_in2 = 1;
+
+      if (is_in2) {
+        energy0[OPS_ACC2(0,0)] = states[i].energy;
+        density0[OPS_ACC3(0,0)] = states[i].density;
+      }
+
+      if (is_in) {
+        xvel0[OPS_ACC4(0,0)] = states[i].xvel;
+        yvel0[OPS_ACC5(0,0)] = states[i].yvel;
       }
     }
     else if(states[i].geometry == g_point) {
-      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(i1,0)] == x_cent && vertexy[OPS_ACC1(0,j1)] == y_cent) {
+            is_in = 1;
+          }
+        }
+      }
+      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent)
+        is_in2 = 1;
+
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
+      }
 
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
       }
     }
   }

--- a/apps/c/CloverLeaf/MPI/generate_chunk_kernel_seq_kernel.cpp
+++ b/apps/c/CloverLeaf/MPI/generate_chunk_kernel_seq_kernel.cpp
@@ -9,6 +9,8 @@ inline void generate_chunk_kernel( const double *vertexx, const double *vertexy,
                      const double *cellx, const double *celly) {
 
   double radius, x_cent, y_cent;
+  int is_in = 0;
+  int is_in2 = 0;
 
 
   energy0[OPS_ACC2(0,0)]= states[0].energy;
@@ -20,59 +22,74 @@ inline void generate_chunk_kernel( const double *vertexx, const double *vertexy,
 
     x_cent=states[i].xmin;
     y_cent=states[i].ymin;
+    is_in = 0;
+    is_in2 = 0;
 
     if (states[i].geometry == g_rect) {
-      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
-
-          energy0[OPS_ACC2(0,0)] = states[i].energy;
-          density0[OPS_ACC3(0,0)] = states[i].density;
-
-          xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
-          yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(1+i1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0)] < states[i].xmax) {
+            if(vertexy[OPS_ACC1(0,1+j1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1)] < states[i].ymax) {
+              is_in = 1;
+            }
+          }
         }
       }
-
-    }
-    else if(states[i].geometry == g_circ) {
-      radius = sqrt ((cellx[OPS_ACC6(0,0)] - x_cent) * (cellx[OPS_ACC6(0,0)] - x_cent) +
-                     (celly[OPS_ACC7(0,0)] - y_cent) * (celly[OPS_ACC7(0,0)] - y_cent));
-      if(radius <= states[i].radius) {
+      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
+          is_in2 = 1;
+        }
+      }
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
-
+      }
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      }
+    }
+    else if(states[i].geometry == g_circ) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          radius = sqrt ((cellx[OPS_ACC6(i1,0)] - x_cent) * (cellx[OPS_ACC6(i1,0)] - x_cent) +
+                     (celly[OPS_ACC7(0,j1)] - y_cent) * (celly[OPS_ACC7(0,j1)] - y_cent));
+          if (radius <= states[i].radius) {
+            is_in = 1;
+          }
+        }
+      }
+      if (radius <= states[i].radius) is_in2 = 1;
+
+      if (is_in2) {
+        energy0[OPS_ACC2(0,0)] = states[i].energy;
+        density0[OPS_ACC3(0,0)] = states[i].density;
+      }
+
+      if (is_in) {
+        xvel0[OPS_ACC4(0,0)] = states[i].xvel;
+        yvel0[OPS_ACC5(0,0)] = states[i].yvel;
       }
     }
     else if(states[i].geometry == g_point) {
-      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(i1,0)] == x_cent && vertexy[OPS_ACC1(0,j1)] == y_cent) {
+            is_in = 1;
+          }
+        }
+      }
+      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent)
+        is_in2 = 1;
+
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
+      }
 
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
       }
     }
   }

--- a/apps/c/CloverLeaf/MPI_OpenMP/generate_chunk_kernel_omp_kernel.cpp
+++ b/apps/c/CloverLeaf/MPI_OpenMP/generate_chunk_kernel_omp_kernel.cpp
@@ -13,6 +13,8 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
                      const double *cellx, const double *celly) {
 
   double radius, x_cent, y_cent;
+  int is_in = 0;
+  int is_in2 = 0;
 
 
   energy0[OPS_ACC2(0,0)]= states[0].energy;
@@ -24,59 +26,74 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
 
     x_cent=states[i].xmin;
     y_cent=states[i].ymin;
+    is_in = 0;
+    is_in2 = 0;
 
     if (states[i].geometry == g_rect) {
-      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
-
-          energy0[OPS_ACC2(0,0)] = states[i].energy;
-          density0[OPS_ACC3(0,0)] = states[i].density;
-
-          xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
-          yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(1+i1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0)] < states[i].xmax) {
+            if(vertexy[OPS_ACC1(0,1+j1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1)] < states[i].ymax) {
+              is_in = 1;
+            }
+          }
         }
       }
-
-    }
-    else if(states[i].geometry == g_circ) {
-      radius = sqrt ((cellx[OPS_ACC6(0,0)] - x_cent) * (cellx[OPS_ACC6(0,0)] - x_cent) +
-                     (celly[OPS_ACC7(0,0)] - y_cent) * (celly[OPS_ACC7(0,0)] - y_cent));
-      if(radius <= states[i].radius) {
+      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
+          is_in2 = 1;
+        }
+      }
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
-
+      }
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      }
+    }
+    else if(states[i].geometry == g_circ) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          radius = sqrt ((cellx[OPS_ACC6(i1,0)] - x_cent) * (cellx[OPS_ACC6(i1,0)] - x_cent) +
+                     (celly[OPS_ACC7(0,j1)] - y_cent) * (celly[OPS_ACC7(0,j1)] - y_cent));
+          if (radius <= states[i].radius) {
+            is_in = 1;
+          }
+        }
+      }
+      if (radius <= states[i].radius) is_in2 = 1;
+
+      if (is_in2) {
+        energy0[OPS_ACC2(0,0)] = states[i].energy;
+        density0[OPS_ACC3(0,0)] = states[i].density;
+      }
+
+      if (is_in) {
+        xvel0[OPS_ACC4(0,0)] = states[i].xvel;
+        yvel0[OPS_ACC5(0,0)] = states[i].yvel;
       }
     }
     else if(states[i].geometry == g_point) {
-      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(i1,0)] == x_cent && vertexy[OPS_ACC1(0,j1)] == y_cent) {
+            is_in = 1;
+          }
+        }
+      }
+      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent)
+        is_in2 = 1;
+
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
+      }
 
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
       }
     }
   }

--- a/apps/c/CloverLeaf/OpenACC/generate_chunk_kernel_openacc_kernel.cpp
+++ b/apps/c/CloverLeaf/OpenACC/generate_chunk_kernel_openacc_kernel.cpp
@@ -3,6 +3,8 @@
 //
 #include "./OpenACC/clover_leaf_common.h"
 
+#define OPS_GPU
+
 extern int xdim0_generate_chunk_kernel;
 int xdim0_generate_chunk_kernel_h = -1;
 extern int xdim1_generate_chunk_kernel;

--- a/apps/c/CloverLeaf/OpenACC/generate_chunk_kernel_openacc_kernel_c.c
+++ b/apps/c/CloverLeaf/OpenACC/generate_chunk_kernel_openacc_kernel_c.c
@@ -3,6 +3,8 @@
 //
 #include "./OpenACC/clover_leaf_common.h"
 
+#define OPS_GPU
+
 int xdim0_generate_chunk_kernel;
 int xdim1_generate_chunk_kernel;
 int xdim2_generate_chunk_kernel;
@@ -40,6 +42,8 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
                      const double *cellx, const double *celly) {
 
   double radius, x_cent, y_cent;
+  int is_in = 0;
+  int is_in2 = 0;
 
 
   energy0[OPS_ACC2(0,0)]= states[0].energy;
@@ -51,59 +55,74 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
 
     x_cent=states[i].xmin;
     y_cent=states[i].ymin;
+    is_in = 0;
+    is_in2 = 0;
 
     if (states[i].geometry == g_rect) {
-      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
-
-          energy0[OPS_ACC2(0,0)] = states[i].energy;
-          density0[OPS_ACC3(0,0)] = states[i].density;
-
-          xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
-          yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(1+i1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0)] < states[i].xmax) {
+            if(vertexy[OPS_ACC1(0,1+j1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1)] < states[i].ymax) {
+              is_in = 1;
+            }
+          }
         }
       }
-
-    }
-    else if(states[i].geometry == g_circ) {
-      radius = sqrt ((cellx[OPS_ACC6(0,0)] - x_cent) * (cellx[OPS_ACC6(0,0)] - x_cent) +
-                     (celly[OPS_ACC7(0,0)] - y_cent) * (celly[OPS_ACC7(0,0)] - y_cent));
-      if(radius <= states[i].radius) {
+      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
+          is_in2 = 1;
+        }
+      }
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
-
+      }
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      }
+    }
+    else if(states[i].geometry == g_circ) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          radius = sqrt ((cellx[OPS_ACC6(i1,0)] - x_cent) * (cellx[OPS_ACC6(i1,0)] - x_cent) +
+                     (celly[OPS_ACC7(0,j1)] - y_cent) * (celly[OPS_ACC7(0,j1)] - y_cent));
+          if (radius <= states[i].radius) {
+            is_in = 1;
+          }
+        }
+      }
+      if (radius <= states[i].radius) is_in2 = 1;
+
+      if (is_in2) {
+        energy0[OPS_ACC2(0,0)] = states[i].energy;
+        density0[OPS_ACC3(0,0)] = states[i].density;
+      }
+
+      if (is_in) {
+        xvel0[OPS_ACC4(0,0)] = states[i].xvel;
+        yvel0[OPS_ACC5(0,0)] = states[i].yvel;
       }
     }
     else if(states[i].geometry == g_point) {
-      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(i1,0)] == x_cent && vertexy[OPS_ACC1(0,j1)] == y_cent) {
+            is_in = 1;
+          }
+        }
+      }
+      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent)
+        is_in2 = 1;
+
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
+      }
 
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
       }
     }
   }

--- a/apps/c/CloverLeaf/generate.cpp
+++ b/apps/c/CloverLeaf/generate.cpp
@@ -47,13 +47,13 @@ void generate()
   int rangexy[] = {x_min-2,x_max+2,y_min-2,y_max+2};
 
   ops_par_loop(generate_chunk_kernel, "generate_chunk_kernel", clover_grid, 2, rangexy,
-    ops_arg_dat(vertexx, 1, S2D_00_P10_STRID2D_X, "double", OPS_READ),
-    ops_arg_dat(vertexy, 1, S2D_00_0P1_STRID2D_Y, "double", OPS_READ),
+    ops_arg_dat(vertexx, 1, S2D_00_P10_M10_STRID2D_X, "double", OPS_READ),
+    ops_arg_dat(vertexy, 1, S2D_00_0P1_0M1_STRID2D_Y, "double", OPS_READ),
     ops_arg_dat(energy0, 1, S2D_00, "double", OPS_WRITE),
     ops_arg_dat(density0, 1, S2D_00, "double", OPS_WRITE),
-    ops_arg_dat(xvel0, 1, S2D_00_P10_0P1_P1P1, "double", OPS_WRITE),
-    ops_arg_dat(yvel0, 1, S2D_00_P10_0P1_P1P1, "double", OPS_WRITE),
-    ops_arg_dat(cellx, 1, S2D_00_P10_STRID2D_X, "double", OPS_READ),
-    ops_arg_dat(celly, 1, S2D_00_0P1_STRID2D_Y, "double", OPS_READ));
+    ops_arg_dat(xvel0, 1, S2D_00, "double", OPS_WRITE),
+    ops_arg_dat(yvel0, 1, S2D_00, "double", OPS_WRITE),
+    ops_arg_dat(cellx, 1, S2D_00_P10_M10_STRID2D_X, "double", OPS_READ),
+    ops_arg_dat(celly, 1, S2D_00_0P1_0M1_STRID2D_Y, "double", OPS_READ));
 
 }

--- a/apps/c/CloverLeaf/generate_chunk_kernel.h
+++ b/apps/c/CloverLeaf/generate_chunk_kernel.h
@@ -12,7 +12,8 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
                      const double *cellx, const double *celly) {
 
   double radius, x_cent, y_cent;
-
+  int is_in = 0;
+  int is_in2 = 0;
   //State 1 is always the background state
 
   energy0[OPS_ACC2(0,0)]= states[0].energy;
@@ -24,62 +25,74 @@ void generate_chunk_kernel( const double *vertexx, const double *vertexy,
 
     x_cent=states[i].xmin;
     y_cent=states[i].ymin;
+    is_in = 0;
+    is_in2 = 0;
 
     if (states[i].geometry == g_rect) {
-      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
-
-          energy0[OPS_ACC2(0,0)] = states[i].energy;
-          density0[OPS_ACC3(0,0)] = states[i].density;
-
-          //S2D_00_P10_0P1_P1P1
-          xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-          xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-          xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
-          yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-          yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-          yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(1+i1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0)] < states[i].xmax) {
+            if(vertexy[OPS_ACC1(0,1+j1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1)] < states[i].ymax) {
+              is_in = 1;
+            }
+          }
         }
       }
-
-    }
-    else if(states[i].geometry == g_circ) {
-      radius = sqrt ((cellx[OPS_ACC6(0,0)] - x_cent) * (cellx[OPS_ACC6(0,0)] - x_cent) +
-                     (celly[OPS_ACC7(0,0)] - y_cent) * (celly[OPS_ACC7(0,0)] - y_cent));
-      if(radius <= states[i].radius) {
+      if(vertexx[OPS_ACC0(1,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1)] >= states[i].ymin && vertexy[OPS_ACC1(0,0)] < states[i].ymax) {
+          is_in2 = 1;
+        }
+      }
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
-
-        //S2D_00_P10_0P1_P1P1
+      }
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
+      }
+    }
+    else if(states[i].geometry == g_circ) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          radius = sqrt ((cellx[OPS_ACC6(i1,0)] - x_cent) * (cellx[OPS_ACC6(i1,0)] - x_cent) +
+                     (celly[OPS_ACC7(0,j1)] - y_cent) * (celly[OPS_ACC7(0,j1)] - y_cent));
+          if (radius <= states[i].radius) {
+            is_in = 1;
+          }
+        }
+      }
+      if (radius <= states[i].radius) is_in2 = 1;
+
+      if (is_in2) {
+        energy0[OPS_ACC2(0,0)] = states[i].energy;
+        density0[OPS_ACC3(0,0)] = states[i].density;
+      }
+
+      if (is_in) {
+        xvel0[OPS_ACC4(0,0)] = states[i].xvel;
+        yvel0[OPS_ACC5(0,0)] = states[i].yvel;
       }
     }
     else if(states[i].geometry == g_point) {
-      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          if(vertexx[OPS_ACC0(i1,0)] == x_cent && vertexy[OPS_ACC1(0,j1)] == y_cent) {
+            is_in = 1;
+          }
+        }
+      }
+      if(vertexx[OPS_ACC0(0,0)] == x_cent && vertexy[OPS_ACC1(0,0)] == y_cent) 
+        is_in2 = 1;
+
+      if (is_in2) {
         energy0[OPS_ACC2(0,0)] = states[i].energy;
         density0[OPS_ACC3(0,0)] = states[i].density;
+      } 
 
-        //S2D_00_P10_0P1_P1P1
+      if (is_in) {
         xvel0[OPS_ACC4(0,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,0)] = states[i].xvel;
-        xvel0[OPS_ACC4(0,1)] = states[i].xvel;
-        xvel0[OPS_ACC4(1,1)] = states[i].xvel;
-
         yvel0[OPS_ACC5(0,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,0)] = states[i].yvel;
-        yvel0[OPS_ACC5(0,1)] = states[i].yvel;
-        yvel0[OPS_ACC5(1,1)] = states[i].yvel;
       }
     }
   }

--- a/apps/c/CloverLeaf/generate_ops.cpp
+++ b/apps/c/CloverLeaf/generate_ops.cpp
@@ -43,13 +43,13 @@ void generate()
   int rangexy[] = {x_min-2,x_max+2,y_min-2,y_max+2};
 
   ops_par_loop_generate_chunk_kernel("generate_chunk_kernel", clover_grid, 2, rangexy,
-               ops_arg_dat(vertexx, 1, S2D_00_P10_STRID2D_X, "double", OPS_READ),
-               ops_arg_dat(vertexy, 1, S2D_00_0P1_STRID2D_Y, "double", OPS_READ),
+               ops_arg_dat(vertexx, 1, S2D_00_P10_M10_STRID2D_X, "double", OPS_READ),
+               ops_arg_dat(vertexy, 1, S2D_00_0P1_0M1_STRID2D_Y, "double", OPS_READ),
                ops_arg_dat(energy0, 1, S2D_00, "double", OPS_WRITE),
                ops_arg_dat(density0, 1, S2D_00, "double", OPS_WRITE),
-               ops_arg_dat(xvel0, 1, S2D_00_P10_0P1_P1P1, "double", OPS_WRITE),
-               ops_arg_dat(yvel0, 1, S2D_00_P10_0P1_P1P1, "double", OPS_WRITE),
-               ops_arg_dat(cellx, 1, S2D_00_P10_STRID2D_X, "double", OPS_READ),
-               ops_arg_dat(celly, 1, S2D_00_0P1_STRID2D_Y, "double", OPS_READ));
+               ops_arg_dat(xvel0, 1, S2D_00, "double", OPS_WRITE),
+               ops_arg_dat(yvel0, 1, S2D_00, "double", OPS_WRITE),
+               ops_arg_dat(cellx, 1, S2D_00_P10_M10_STRID2D_X, "double", OPS_READ),
+               ops_arg_dat(celly, 1, S2D_00_0P1_0M1_STRID2D_Y, "double", OPS_READ));
 
 }

--- a/apps/c/CloverLeaf_3D/CUDA/generate_chunk_kernel_cuda_kernel.cu
+++ b/apps/c/CloverLeaf_3D/CUDA/generate_chunk_kernel_cuda_kernel.cu
@@ -81,6 +81,7 @@ void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
 
   energy0[OPS_ACC3(0,0,0)]= states[0].energy;
@@ -96,59 +97,75 @@ void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;
+          }
+        }
+      }
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D/MPI/generate_chunk_kernel_seq_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/MPI/generate_chunk_kernel_seq_kernel.cpp
@@ -10,6 +10,7 @@ inline void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
 
   energy0[OPS_ACC3(0,0,0)]= states[0].energy;
@@ -25,59 +26,75 @@ inline void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;
+          }
+        }
+      }
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D/MPI_OpenMP/generate_chunk_kernel_omp_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/MPI_OpenMP/generate_chunk_kernel_omp_kernel.cpp
@@ -14,6 +14,7 @@ void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
 
   energy0[OPS_ACC3(0,0,0)]= states[0].energy;
@@ -29,59 +30,75 @@ void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;
+          }
+        }
+      }
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D/OpenACC/generate_chunk_kernel_openacc_kernel.cpp
+++ b/apps/c/CloverLeaf_3D/OpenACC/generate_chunk_kernel_openacc_kernel.cpp
@@ -3,6 +3,8 @@
 //
 #include "./OpenACC/clover_leaf_common.h"
 
+#define OPS_GPU
+
 extern int xdim0_generate_chunk_kernel;
 int xdim0_generate_chunk_kernel_h = -1;
 extern int ydim0_generate_chunk_kernel;

--- a/apps/c/CloverLeaf_3D/OpenACC/generate_chunk_kernel_openacc_kernel_c.c
+++ b/apps/c/CloverLeaf_3D/OpenACC/generate_chunk_kernel_openacc_kernel_c.c
@@ -3,6 +3,8 @@
 //
 #include "./OpenACC/clover_leaf_common.h"
 
+#define OPS_GPU
+
 int xdim0_generate_chunk_kernel;
 int ydim0_generate_chunk_kernel;
 int xdim1_generate_chunk_kernel;
@@ -61,6 +63,7 @@ void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
 
   energy0[OPS_ACC3(0,0,0)]= states[0].energy;
@@ -76,59 +79,75 @@ void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;
+          }
+        }
+      }
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D/generate.cpp
+++ b/apps/c/CloverLeaf_3D/generate.cpp
@@ -50,15 +50,15 @@ void generate()
   int rangexyz[] = {x_min-2,x_max+2,y_min-2,y_max+2,z_min-2,z_max+2};
 
   ops_par_loop(generate_chunk_kernel, "generate_chunk_kernel", clover_grid, 3, rangexyz,
-    ops_arg_dat(vertexx,  1, S3D_000_P100_STRID3D_X, "double", OPS_READ),
-    ops_arg_dat(vertexy,  1, S3D_000_0P10_STRID3D_Y, "double", OPS_READ),
-    ops_arg_dat(vertexz,  1, S3D_000_00P1_STRID3D_Z, "double", OPS_READ),
+    ops_arg_dat(vertexx,  1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+    ops_arg_dat(vertexy,  1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+    ops_arg_dat(vertexz,  1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ),
     ops_arg_dat(energy0,  1, S3D_000, "double", OPS_WRITE),
     ops_arg_dat(density0, 1, S3D_000, "double", OPS_WRITE),
-    ops_arg_dat(xvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(yvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(zvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(cellx,    1, S3D_000_STRID3D_X, "double", OPS_READ),
-    ops_arg_dat(celly,    1, S3D_000_STRID3D_Y, "double", OPS_READ),
-    ops_arg_dat(cellz,    1, S3D_000_STRID3D_Z, "double", OPS_READ));
+    ops_arg_dat(xvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(yvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(zvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(cellx,    1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+    ops_arg_dat(celly,    1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+    ops_arg_dat(cellz,    1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ));
 }

--- a/apps/c/CloverLeaf_3D/generate_chunk_kernel.h
+++ b/apps/c/CloverLeaf_3D/generate_chunk_kernel.h
@@ -13,6 +13,7 @@ void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
   //State 1 is always the background state
 
@@ -29,59 +30,75 @@ void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;      
+          }
+        }
+      } 
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+ 
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D/generate_ops.cpp
+++ b/apps/c/CloverLeaf_3D/generate_ops.cpp
@@ -49,15 +49,15 @@ void generate()
   int rangexyz[] = {x_min-2,x_max+2,y_min-2,y_max+2,z_min-2,z_max+2};
 
   ops_par_loop_generate_chunk_kernel("generate_chunk_kernel", clover_grid, 3, rangexyz,
-               ops_arg_dat(vertexx, 1, S3D_000_P100_STRID3D_X, "double", OPS_READ),
-               ops_arg_dat(vertexy, 1, S3D_000_0P10_STRID3D_Y, "double", OPS_READ),
-               ops_arg_dat(vertexz, 1, S3D_000_00P1_STRID3D_Z, "double", OPS_READ),
+               ops_arg_dat(vertexx, 1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+               ops_arg_dat(vertexy, 1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+               ops_arg_dat(vertexz, 1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ),
                ops_arg_dat(energy0, 1, S3D_000, "double", OPS_WRITE),
                ops_arg_dat(density0, 1, S3D_000, "double", OPS_WRITE),
-               ops_arg_dat(xvel0, 1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-               ops_arg_dat(yvel0, 1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-               ops_arg_dat(zvel0, 1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-               ops_arg_dat(cellx, 1, S3D_000_STRID3D_X, "double", OPS_READ),
-               ops_arg_dat(celly, 1, S3D_000_STRID3D_Y, "double", OPS_READ),
-               ops_arg_dat(cellz, 1, S3D_000_STRID3D_Z, "double", OPS_READ));
+               ops_arg_dat(xvel0, 1, S3D_000, "double", OPS_WRITE),
+               ops_arg_dat(yvel0, 1, S3D_000, "double", OPS_WRITE),
+               ops_arg_dat(zvel0, 1, S3D_000, "double", OPS_WRITE),
+               ops_arg_dat(cellx, 1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+               ops_arg_dat(celly, 1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+               ops_arg_dat(cellz, 1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ));
 }

--- a/apps/c/CloverLeaf_3D_HDF5/generate_chunk_kernel.h
+++ b/apps/c/CloverLeaf_3D_HDF5/generate_chunk_kernel.h
@@ -13,6 +13,7 @@ void generate_chunk_kernel( const double *vertexx,
                      const double *cellx, const double *celly, const double *cellz) {
 
   double radius, x_cent, y_cent, z_cent;
+  int is_in = 0;
 
   //State 1 is always the background state
 
@@ -29,59 +30,75 @@ void generate_chunk_kernel( const double *vertexx,
     z_cent=states[i].zmin;
 
     if (states[i].geometry == g_cube) {
-      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
-        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
-          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
-
-            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-            density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-            for (int ix=0;ix<2;ix++){
-              for (int iy=0;iy<2;iy++){
-                for (int iz=0;iz<2;iz++){
-                  xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-                  yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-                  zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(1+i1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0+i1,0,0)] < states[i].xmax) {
+              if(vertexy[OPS_ACC1(0,1+j1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0+j1,0)] < states[i].ymax) {
+                if(vertexz[OPS_ACC2(0,0,1+k1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0+k1)] < states[i].zmax) {
+                  is_in=1;
                 }
               }
             }
           }
         }
       }
-    }
-    else if(states[i].geometry == g_sphe) {
-      radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
-                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
-                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
-      if(radius <= states[i].radius) {
-        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
-        density0[OPS_ACC4(0,0,0)] = states[i].density;
 
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
+      if(vertexx[OPS_ACC0(1,0,0)] >= states[i].xmin  && vertexx[OPS_ACC0(0,0,0)] < states[i].xmax) {
+        if(vertexy[OPS_ACC1(0,1,0)] >= states[i].ymin && vertexy[OPS_ACC1(0,0,0)] < states[i].ymax) {
+          if(vertexz[OPS_ACC2(0,0,1)] >= states[i].zmin && vertexz[OPS_ACC2(0,0,0)] < states[i].zmax) {
+            energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+            density0[OPS_ACC4(0,0,0)] = states[i].density;
           }
         }
       }
+
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+      }
+    }
+    else if(states[i].geometry == g_sphe) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            radius = sqrt ((cellx[OPS_ACC8(0,0,0)] - x_cent) * (cellx[OPS_ACC8(0,0,0)] - x_cent) +
+                     (celly[OPS_ACC9(0,0,0)] - y_cent) * (celly[OPS_ACC9(0,0,0)] - y_cent) +
+                     (cellz[OPS_ACC10(0,0,0)] - z_cent) * (cellz[OPS_ACC10(0,0,0)] - z_cent));
+            if(radius <= states[i].radius) is_in = 1;      
+          }
+        }
+      } 
+      if(radius <= states[i].radius) {
+        energy0[OPS_ACC3(0,0,0)] = states[i].energy;
+        density0[OPS_ACC4(0,0,0)] = states[i].density;
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
+ 
+      }
     }
     else if(states[i].geometry == g_point) {
+      for (int i1 = -1; i1 <= 0; i1++) {
+        for (int j1 = -1; j1 <= 0; j1++) {
+          for (int k1 = -1; k1 <= 0; k1++) {
+            if(vertexx[OPS_ACC0(0+i1,0,0)] == x_cent && vertexy[OPS_ACC1(0,0+j1,0)] == y_cent && vertexz[OPS_ACC2(0,0,0+k1)] == z_cent)
+              is_in = 1;
+          }
+        }
+      }
+
       if(vertexx[OPS_ACC0(0,0,0)] == x_cent && vertexy[OPS_ACC1(0,0,0)] == y_cent && vertexz[OPS_ACC2(0,0,0)] == z_cent) {
         energy0[OPS_ACC3(0,0,0)] = states[i].energy;
         density0[OPS_ACC4(0,0,0)] = states[i].density;
-
-        for (int ix=0;ix<2;ix++){
-          for (int iy=0;iy<2;iy++){
-            for (int iz=0;iz<2;iz++){
-              xvel0[OPS_ACC5(ix,iy,iz)] = states[i].xvel;
-              yvel0[OPS_ACC6(ix,iy,iz)] = states[i].yvel;
-              zvel0[OPS_ACC7(ix,iy,iz)] = states[i].zvel;
-            }
-          }
-        }
+      }
+      if (is_in) {
+        xvel0[OPS_ACC5(0,0,0)] = states[i].xvel;
+        yvel0[OPS_ACC6(0,0,0)] = states[i].yvel;
+        zvel0[OPS_ACC7(0,0,0)] = states[i].zvel;
       }
     }
   }

--- a/apps/c/CloverLeaf_3D_HDF5/generate_hdf5.cpp
+++ b/apps/c/CloverLeaf_3D_HDF5/generate_hdf5.cpp
@@ -50,17 +50,17 @@ void generate_hdf5()
   int rangexyz[] = {x_min-2,x_max+2,y_min-2,y_max+2,z_min-2,z_max+2};
 
   ops_par_loop(generate_chunk_kernel, "generate_chunk_kernel", clover_grid, 3, rangexyz,
-    ops_arg_dat(vertexx,  1, S3D_000_P100_STRID3D_X, "double", OPS_READ),
-    ops_arg_dat(vertexy,  1, S3D_000_0P10_STRID3D_Y, "double", OPS_READ),
-    ops_arg_dat(vertexz,  1, S3D_000_00P1_STRID3D_Z, "double", OPS_READ),
+    ops_arg_dat(vertexx,  1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+    ops_arg_dat(vertexy,  1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+    ops_arg_dat(vertexz,  1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ),
     ops_arg_dat(energy0,  1, S3D_000, "double", OPS_WRITE),
     ops_arg_dat(density0, 1, S3D_000, "double", OPS_WRITE),
-    ops_arg_dat(xvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(yvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(zvel0,    1, S3D_000_fP1P1P1, "double", OPS_WRITE),
-    ops_arg_dat(cellx,    1, S3D_000_STRID3D_X, "double", OPS_READ),
-    ops_arg_dat(celly,    1, S3D_000_STRID3D_Y, "double", OPS_READ),
-    ops_arg_dat(cellz,    1, S3D_000_STRID3D_Z, "double", OPS_READ));
+    ops_arg_dat(xvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(yvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(zvel0,    1, S3D_000, "double", OPS_WRITE),
+    ops_arg_dat(cellx,    1, S3D_000_P100_M100_STRID3D_X, "double", OPS_READ),
+    ops_arg_dat(celly,    1, S3D_000_0P10_0M10_STRID3D_Y, "double", OPS_READ),
+    ops_arg_dat(cellz,    1, S3D_000_00P1_00M1_STRID3D_Z, "double", OPS_READ));
 
     ops_fetch_block_hdf5_file(clover_grid, "cloverdata.h5");
 

--- a/apps/c/mb_shsgc/Max_datatransfer/shsgc.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/shsgc.cpp
@@ -409,9 +409,9 @@ int main(int argc, char **argv) {
                    ops_arg_dat(rho_new[i],  1, S1D_01, "double",OPS_READ),
                    ops_arg_dat(rhou_new[i], 1, S1D_01, "double",OPS_READ),
                    ops_arg_dat(rhoE_new[i], 1, S1D_01, "double",OPS_READ),
-                   ops_arg_dat(alam[i],     3, S1D_01, "double",OPS_WRITE),
-                   ops_arg_dat(r[i],        9, S1D_01, "double",OPS_WRITE),
-                   ops_arg_dat(al[i],       3, S1D_01, "double",OPS_WRITE));
+                   ops_arg_dat(alam[i],     3, S1D_0, "double",OPS_WRITE),
+                   ops_arg_dat(r[i],        9, S1D_0, "double",OPS_WRITE),
+                   ops_arg_dat(al[i],       3, S1D_0, "double",OPS_WRITE));
 
       // limiter function
       int tvd_limiter_range[] = {sizes[(2*i)]+1-xhalo,sizes[(2*i)+1]+xhalo-1};

--- a/apps/c/mb_shsgc/Max_datatransfer/shsgc_ops.cpp
+++ b/apps/c/mb_shsgc/Max_datatransfer/shsgc_ops.cpp
@@ -485,9 +485,9 @@ int main(int argc, char **argv) {
                    ops_arg_dat(rho_new[i], 1, S1D_01, "double", OPS_READ),
                    ops_arg_dat(rhou_new[i], 1, S1D_01, "double", OPS_READ),
                    ops_arg_dat(rhoE_new[i], 1, S1D_01, "double", OPS_READ),
-                   ops_arg_dat(alam[i], 3, S1D_01, "double", OPS_WRITE),
-                   ops_arg_dat(r[i], 9, S1D_01, "double", OPS_WRITE),
-                   ops_arg_dat(al[i], 3, S1D_01, "double", OPS_WRITE));
+                   ops_arg_dat(alam[i], 3, S1D_0, "double", OPS_WRITE),
+                   ops_arg_dat(r[i], 9, S1D_0, "double", OPS_WRITE),
+                   ops_arg_dat(al[i], 3, S1D_0, "double", OPS_WRITE));
 
       int tvd_limiter_range[] = {sizes[(2*i)]+1-xhalo,sizes[(2*i)+1]+xhalo-1};
       ops_par_loop_limiter_kernel("limiter_kernel", shsgc_grid[i], 1, tvd_limiter_range,

--- a/apps/c/shsgc/shsgc.cpp
+++ b/apps/c/shsgc/shsgc.cpp
@@ -334,9 +334,9 @@ int main(int argc, char **argv) {
                  ops_arg_dat(rho_new,  1, S1D_01, "double",OPS_READ),
                  ops_arg_dat(rhou_new,  1, S1D_01, "double",OPS_READ),
                  ops_arg_dat(rhoE_new,  1, S1D_01, "double",OPS_READ),
-                 ops_arg_dat(alam,  3, S1D_01, "double",OPS_WRITE),
-                 ops_arg_dat(r,  9, S1D_01, "double",OPS_WRITE),
-                 ops_arg_dat(al, 3, S1D_01, "double",OPS_WRITE));
+                 ops_arg_dat(alam,  3, S1D_0, "double",OPS_WRITE),
+                 ops_arg_dat(r,  9, S1D_0, "double",OPS_WRITE),
+                 ops_arg_dat(al, 3, S1D_0, "double",OPS_WRITE));
 
     // limiter function
     int nxp_range_4[] = {1,nxp};

--- a/apps/c/shsgc/shsgc_ops.cpp
+++ b/apps/c/shsgc/shsgc_ops.cpp
@@ -376,9 +376,9 @@ int main(int argc, char **argv) {
                  ops_arg_dat(rho_new, 1, S1D_01, "double", OPS_READ),
                  ops_arg_dat(rhou_new, 1, S1D_01, "double", OPS_READ),
                  ops_arg_dat(rhoE_new, 1, S1D_01, "double", OPS_READ),
-                 ops_arg_dat(alam, 3, S1D_01, "double", OPS_WRITE),
-                 ops_arg_dat(r, 9, S1D_01, "double", OPS_WRITE),
-                 ops_arg_dat(al, 3, S1D_01, "double", OPS_WRITE));
+                 ops_arg_dat(alam, 3, S1D_0, "double", OPS_WRITE),
+                 ops_arg_dat(r, 9, S1D_0, "double", OPS_WRITE),
+                 ops_arg_dat(al, 3, S1D_0, "double", OPS_WRITE));
 
     int nxp_range_4[] = {1,nxp};
     ops_par_loop_limiter_kernel("limiter_kernel", shsgc_grid, 1, nxp_range_4,

--- a/apps/fortran/shsgc/shsgc.F90
+++ b/apps/fortran/shsgc/shsgc.F90
@@ -278,9 +278,9 @@ program SHSGC
             & ops_arg_dat(rho_new,  1, S1D_01, "real(8)",OPS_READ), &
             & ops_arg_dat(rhou_new,  1, S1D_01, "real(8)",OPS_READ), &
             & ops_arg_dat(rhoE_new,  1, S1D_01, "real(8)",OPS_READ), &
-            & ops_arg_dat(alam,  3, S1D_01, "real(8)",OPS_WRITE), &
-            & ops_arg_dat(r,  9, S1D_01, "real(8)",OPS_WRITE), &
-            & ops_arg_dat(al, 3, S1D_01, "real(8)",OPS_WRITE))
+            & ops_arg_dat(alam,  3, S1D_0, "real(8)",OPS_WRITE), &
+            & ops_arg_dat(r,  9, S1D_0, "real(8)",OPS_WRITE), &
+            & ops_arg_dat(al, 3, S1D_0, "real(8)",OPS_WRITE))
 
     ! limiter function
     nxp_range_4(1) = 2

--- a/apps/fortran/shsgc/shsgc_ops.F90
+++ b/apps/fortran/shsgc/shsgc_ops.F90
@@ -254,9 +254,9 @@ program SHSGC
                       & ops_arg_dat(rho_new, 1, S1D_01, "real(8)", OPS_READ), &
                       & ops_arg_dat(rhou_new, 1, S1D_01, "real(8)", OPS_READ), &
                       & ops_arg_dat(rhoE_new, 1, S1D_01, "real(8)", OPS_READ), &
-                      & ops_arg_dat(alam, 3, S1D_01, "real(8)", OPS_WRITE), &
-                      & ops_arg_dat(r, 9, S1D_01, "real(8)", OPS_WRITE), &
-                      & ops_arg_dat(al, 3, S1D_01, "real(8)", OPS_WRITE))
+                      & ops_arg_dat(alam, 3, S1D_0, "real(8)", OPS_WRITE), &
+                      & ops_arg_dat(r, 9, S1D_0, "real(8)", OPS_WRITE), &
+                      & ops_arg_dat(al, 3, S1D_0, "real(8)", OPS_WRITE))
 
     nxp_range_4(1) = 2
     nxp_range_4(2) = nxp-1

--- a/ops/c/include/ops_lib_cpp.h
+++ b/ops/c/include/ops_lib_cpp.h
@@ -77,9 +77,9 @@ ops_arg ops_arg_gbl ( T * data, int dim, char const * type, ops_access acc )
 template < class T >
 void ops_decl_const2 ( char const * name, int dim, char const *type, T * data )
 {
-  if ( type_error ( data, type ) )
-  {
-    printf ( "incorrect type specified for constant \"%s\" \n", name ); exit ( 1 );
+  if ( type_error ( data, type ) ) {
+    printf ( "Error: incorrect type specified for constant \"%s\" \n", name );
+    exit ( 1 );
   }
 
   ops_decl_const_char ( dim, type, sizeof ( T ), (char *) data, name );
@@ -89,7 +89,7 @@ template < class T >
 void ops_reduction_result(ops_reduction handle, T *ptr) {
   if ( type_error ( ptr, handle->type ) )
   {
-    printf ( "incorrect type specified for constant in ops_reduction_result" );
+    printf ( "Error: incorrect type specified for constant in ops_reduction_result" );
     exit ( 1 );
   }
   ops_reduction_result_char(handle, sizeof ( T ), (char *) ptr);
@@ -101,7 +101,7 @@ void ops_update_const ( char const * name, int dim, char const * type, T * data 
   (void)dim;
   if ( type_error ( data, type ) )
   {
-    printf ( "incorrect type specified for constant in ops_update_const" );
+    printf ( "Error: incorrect type specified for constant in ops_update_const" );
     exit ( 1 );
   }
   ops_execute();
@@ -114,7 +114,7 @@ void ops_decl_const ( char const * name, int dim, char const * type, T * data )
   (void)dim;
   if ( type_error ( data, type ) )
   {
-    printf ( "incorrect type specified for constant in op_decl_const" );
+    printf ( "Error: incorrect type specified for constant in op_decl_const" );
     exit ( 1 );
   }
 }
@@ -144,7 +144,7 @@ ops_dat ops_decl_dat ( ops_block block, int data_size,
 {
 
   if ( type_error ( data, type ) ) {
-    printf ( "incorrect type specified for dataset \"%s\" \n", name );
+    printf ( "Error: incorrect type specified for dataset \"%s\" \n", name );
     exit ( 1 );
   }
 

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -645,6 +645,10 @@ ops_arg ops_arg_dat_core ( ops_dat dat, ops_stencil stencil, ops_access acc ) {
   arg.argtype = OPS_ARG_DAT;
   arg.dat = dat;
   arg.stencil = stencil;
+  if (acc != OPS_READ && stencil->points != 1) {
+    printf("Error: OPS does not support OPS_WRITE/OPS_RW/OPS_INC arguments with a non (0,0,0) stencil due to potential race conditions\n");
+    exit(-1);
+  }
   if ( dat != NULL ) {
     arg.data = dat->data;
     arg.data_d = dat->data_d;

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -507,17 +507,20 @@ ops_arg ops_arg_reduce_core ( ops_reduction handle, int dim, const char *type, o
     handle->initialized = 1;
     handle->acc = acc;
     if (acc == OPS_INC) memset(handle->data, 0, handle->size);
-    if (strcmp(type,"double")==0) { //TODO: handle other types
+    if (strcmp(type,"double")==0 || strcmp(type,"real(8)")==0) { //TODO: handle other types
       if (acc == OPS_MIN) for (int i = 0; i < handle->size/8; i++) ((double*)handle->data)[i] = DBL_MAX;
       if (acc == OPS_MAX) for (int i = 0; i < handle->size/8; i++) ((double*)handle->data)[i] = -1.0*DBL_MAX;
     }
-    else if (strcmp(type,"float")==0) {
+    else if (strcmp(type,"float")==0 || strcmp(type,"real(4)")==0) {
       if (acc == OPS_MIN) for (int i = 0; i < handle->size/4; i++) ((float*)handle->data)[i] = FLT_MAX;
       if (acc == OPS_MAX) for (int i = 0; i < handle->size/4; i++) ((float*)handle->data)[i] = -1.0f*FLT_MAX;
     }
-    else if (strcmp(type,"int")==0) {
+    else if (strcmp(type,"int")==0 || strcmp(type,"integer")==0) {
       if (acc == OPS_MIN) for (int i = 0; i < handle->size/4; i++) ((int*)handle->data)[i] = INT_MAX;
       if (acc == OPS_MAX) for (int i = 0; i < handle->size/4; i++) ((int*)handle->data)[i] = -1*INT_MAX;
+    }
+    else {
+      printf("Warning, reduction type not recognised, please add in ops_lib_core.c!\n");
     }
   } else if (handle->acc != acc) {
     printf("ops_reduction handle %s was aleady used with a different access type\n",handle->name);

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -294,7 +294,7 @@ void ops_exit_core( )
 ops_block ops_decl_block(int dims, const char *name)
 {
   if ( dims < 0 ) {
-    printf ( " ops_decl_block error -- negative/zero dimension size for block: %s\n", name );
+    printf ( "Error: ops_decl_block -- negative/zero dimension size for block: %s\n", name );
     exit ( -1 );
   }
 
@@ -303,7 +303,7 @@ ops_block ops_decl_block(int dims, const char *name)
     OPS_block_list = (ops_block_descriptor *) realloc(OPS_block_list,OPS_block_max * sizeof(ops_block_descriptor));
 
     if ( OPS_block_list == NULL ) {
-      printf ( " ops_decl_block error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_block -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -335,12 +335,12 @@ ops_dat ops_decl_dat_core( ops_block block, int dim,
                       char const * name )
 {
   if ( block == NULL ) {
-    printf ( "ops_decl_dat error -- invalid block for data: %s\n", name );
+    printf ( "Error: ops_decl_dat -- invalid block for data: %s\n", name );
     exit ( -1 );
   }
 
   if ( dim <= 0 ) {
-    printf ( "ops_decl_dat error -- negative/zero number of items per grid point in data: %s\n", name );
+    printf ( "Error: ops_decl_dat -- negative/zero number of items per grid point in data: %s\n", name );
     exit ( -1 );
   }
 
@@ -391,7 +391,7 @@ ops_dat ops_decl_dat_core( ops_block block, int dim,
   //add the newly created ops_dat to list
   item = (ops_dat_entry *)malloc(sizeof(ops_dat_entry));
   if (item == NULL) {
-    printf ( " op_decl_dat error -- error allocating memory to double linked list entry\n" );
+    printf ( "Error: op_decl_dat -- error allocating memory to double linked list entry\n" );
     exit ( -1 );
   }
   item->dat = dat;
@@ -403,7 +403,7 @@ ops_dat ops_decl_dat_core( ops_block block, int dim,
   //Another entry for a different list
   item = (ops_dat_entry *)malloc(sizeof(ops_dat_entry));
   if (item == NULL) {
-    printf ( " op_decl_dat error -- error allocating memory to double linked list entry\n" );
+    printf ( "Error: op_decl_dat -- error allocating memory to double linked list entry\n" );
     exit ( -1 );
   }
   item->dat = dat;
@@ -420,7 +420,7 @@ ops_dat ops_decl_dat_temp_core ( ops_block block, int dim,
   //Check if this dat already exists in the double linked list
   ops_dat found_dat = search_dat(block, dim, dataset_size, base, type, name);
   if ( found_dat != NULL) {
-    printf("ops_dat with name %s already exists, cannot create temporary ops_dat\n ", name);
+    printf("Error: ops_dat with name %s already exists, cannot create temporary ops_dat\n ", name);
     exit(2);
   }
   //if not found ...
@@ -436,7 +436,7 @@ ops_stencil ops_decl_stencil ( int dims, int points, int *sten, char const * nam
     OPS_stencil_list = (ops_stencil *) realloc(OPS_stencil_list,OPS_stencil_max * sizeof(ops_stencil));
 
     if ( OPS_stencil_list == NULL ) {
-      printf ( " ops_decl_stencil error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_stencil -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -449,10 +449,6 @@ ops_stencil ops_decl_stencil ( int dims, int points, int *sten, char const * nam
 
   stencil->stencil = (int *)xmalloc(dims*points*sizeof(int));
   memcpy(stencil->stencil,sten,sizeof(int)*dims*points);
-
-  //for (int i = 0; i < dims*points; i++)
-  //  printf("%d ",stencil->stencil[i]);
-  //printf("\n");
 
   stencil->stride = (int *)xmalloc(dims*sizeof(int));
   for (int i = 0; i < dims; i++) stencil->stride[i] = 1;
@@ -472,7 +468,7 @@ ops_stencil ops_decl_strided_stencil ( int dims, int points, int *sten, int *str
     OPS_stencil_list = (ops_stencil *) realloc(OPS_stencil_list,OPS_stencil_max * sizeof(ops_stencil));
 
     if ( OPS_stencil_list == NULL ) {
-      printf ( " ops_decl_stencil error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_stencil -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -520,10 +516,10 @@ ops_arg ops_arg_reduce_core ( ops_reduction handle, int dim, const char *type, o
       if (acc == OPS_MAX) for (int i = 0; i < handle->size/4; i++) ((int*)handle->data)[i] = -1*INT_MAX;
     }
     else {
-      printf("Warning, reduction type not recognised, please add in ops_lib_core.c!\n");
+      printf("Warning: reduction type not recognised, please add in ops_lib_core.c !\n");
     }
   } else if (handle->acc != acc) {
-    printf("ops_reduction handle %s was aleady used with a different access type\n",handle->name);
+    printf("Error: ops_reduction handle %s was aleady used with a different access type\n",handle->name);
     exit(-1);
   }
   return arg;
@@ -535,7 +531,7 @@ ops_halo_group ops_decl_halo_group(int nhalos, ops_halo halos[nhalos]) {
     OPS_halo_group_list = (ops_halo_group *) realloc(OPS_halo_group_list,OPS_halo_group_max * sizeof(ops_halo_group));
 
     if ( OPS_halo_group_list == NULL ) {
-      printf ( " ops_decl_halo_group error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_halo_group -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -564,7 +560,7 @@ if ( OPS_halo_group_index == OPS_halo_group_max ) {
     OPS_halo_group_list = (ops_halo_group *) realloc(OPS_halo_group_list,OPS_halo_group_max * sizeof(ops_halo_group));
 
     if ( OPS_halo_group_list == NULL ) {
-      printf ( " ops_decl_halo_group error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_halo_group -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -612,7 +608,7 @@ ops_halo ops_decl_halo_core(ops_dat from, ops_dat to, int *iter_size, int* from_
     OPS_halo_list = (ops_halo *) realloc(OPS_halo_list,OPS_halo_max * sizeof(ops_halo));
 
     if ( OPS_halo_list == NULL ) {
-      printf ( " ops_decl_halo_core error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_halo_core -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -691,7 +687,7 @@ ops_reduction ops_decl_reduction_handle_core(int size, const char *type, const c
     OPS_reduction_list = (ops_reduction *) realloc(OPS_reduction_list,OPS_reduction_max * sizeof(ops_reduction));
 
     if ( OPS_reduction_list == NULL ) {
-      printf ( " ops_decl_reduction_handle error -- error reallocating memory\n" );
+      printf ( "Error: ops_decl_reduction_handle -- error reallocating memory\n" );
       exit ( -1 );
     }
   }
@@ -789,12 +785,12 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
   //TODO: this has to be backend-specific
   FILE *fp;
   if ( (fp = fopen(file_name,"a")) == NULL) {
-    printf("can't open file %s\n",file_name);
+    printf("Error: can't open file %s\n",file_name);
     exit(2);
   }
 
   if (fprintf(fp,"ops_dat:  %s \n", dat->name)<0) {
-    printf("error writing to %s\n",file_name);
+    printf("Error: error writing to %s\n",file_name);
     exit(2);
   }
   if (fprintf(fp,"ops_dat dim:  %d \n", dat->dim)<0) {
@@ -809,7 +805,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
 
   for(int i = 0; i < dat->block->dims; i++) {
     if (fprintf(fp,"[%d]", dat->size[i])<0) {
-      printf("error writing to %s\n",file_name);
+      printf("Error: error writing to %s\n",file_name);
       exit(2);
     }
   }
@@ -817,7 +813,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
 
 
   if (fprintf(fp,"elem size %d \n", dat->elem_size)<0) {
-    printf("error writing to %s\n",file_name);
+    printf("Error: error writing to %s\n",file_name);
     exit(2);
   }
 
@@ -831,7 +827,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
             if (fprintf(fp, " %3.10lf",
               ((double *)dat->data)[i*dat->size[1]*dat->size[0]+
                                     j*dat->size[0]+k])<0) {
-              printf("error writing to %s\n",file_name);
+              printf("Error: error writing to %s\n",file_name);
               exit(2);
               }
           }
@@ -847,7 +843,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
           for(int k = 0; k < dat->size[0]; k++ ) {
             if (fprintf(fp, "%e ", ((float *)dat->data)[i*dat->size[1]*dat->size[0]+
                                       j*dat->size[0]+k])<0) {
-              printf("error writing to %s\n",file_name);
+              printf("Error: error writing to %s\n",file_name);
               exit(2);
               }
           }
@@ -865,7 +861,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
           for(int k = 0; k < dat->size[0]; k++ ) {
             if (fprintf(fp, "%d ", ((int *)dat->data)[i*dat->size[1]*dat->size[0]+
                                       j*dat->size[0]+k])<0) {
-              printf("error writing to %s\n",file_name);
+              printf("Error: error writing to %s\n",file_name);
               exit(2);
             }
           }
@@ -875,7 +871,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       }
     }
     else {
-      printf("Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
+      printf("Error: Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
       exit(2);
     }
     fprintf(fp,"\n");
@@ -888,7 +884,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
         for(int j = 0; j < dat->size[0]; j++ ) {
           for(int d = 0; d < dat->dim; d++ ) {
             if (fprintf(fp, " %3.10lf",((double *)dat->data)[(i*dat->size[0]+j)*dat->dim+d])<0) {
-              printf("error writing to %s\n",file_name);
+              printf("Error: error writing to %s\n",file_name);
               exit(2);
             }
           }
@@ -902,7 +898,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
         for(int j = 0; j < dat->size[0]; j++ ) {
           for(int d = 0; d < dat->dim; d++ ) {
             if (fprintf(fp, " %e",((float *)dat->data)[(i*dat->size[0]+j)*dat->dim+d])<0) {
-            printf("error writing to %s\n",file_name);
+            printf("Error: error writing to %s\n",file_name);
             exit(2);
             }
           }
@@ -918,7 +914,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
         for(int j = 0; j < dat->size[0]; j++ ) {
           for(int d = 0; d < dat->dim; d++ ) {
             if (fprintf(fp, "%d ", ((int *)dat->data)[(i*dat->size[0]+j)*dat->dim+d])<0) {
-              printf("error writing to %s\n",file_name);
+              printf("Error: error writing to %s\n",file_name);
               exit(2);
             }
           }
@@ -927,7 +923,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       }
     }
     else {
-      printf("Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
+      printf("Error: Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
       exit(2);
     }
     fprintf(fp,"\n");
@@ -940,7 +936,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       for(int j = 0; j < dat->size[0]; j++ ) {
         for(int d = 0; d < dat->dim; d++ ) {
           if (fprintf(fp, "%3.10lf", ((double *)dat->data)[j*dat->dim+d])<0) {
-            printf("error writing to %s\n",file_name);
+            printf("Error: error writing to %s\n",file_name);
             exit(2);
           }
           if(d<dat->dim-1)fprintf(fp," ");
@@ -953,7 +949,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       for(int j = 0; j < dat->size[0]; j++ ) {
         for(int d = 0; d < dat->dim; d++ ) {
           if (fprintf(fp, "%e\n", ((float *)dat->data)[j*dat->dim+d])<0) {
-            printf("error writing to %s\n",file_name);
+            printf("Error: error writing to %s\n",file_name);
             exit(2);
           }
         }
@@ -967,7 +963,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       for(int j = 0; j < dat->size[0]; j++ ) {
         for(int d = 0; d < dat->dim; d++ ) {
           if (fprintf(fp, "%d\n", ((int *)dat->data)[j*dat->dim+d])<0) {
-            printf("error writing to %s\n",file_name);
+            printf("Error: error writing to %s\n",file_name);
             exit(2);
           }
         }
@@ -975,7 +971,7 @@ void ops_print_dat_to_txtfile_core(ops_dat dat, const char* file_name)
       fprintf(fp,"\n");
     }
     else {
-      printf("Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
+      printf("Error: Unknown type %s, cannot be written to file %s\n",dat->type,file_name);
       exit(2);
     }
     fprintf(fp,"\n");
@@ -1057,7 +1053,7 @@ ops_timing_realloc ( int kernel, const char *name )
     OPS_kernels = ( ops_kernel * ) realloc ( OPS_kernels, OPS_kern_max_new * sizeof ( ops_kernel ) );
     if ( OPS_kernels == NULL )
     {
-      printf ( " ops_timing_realloc error \n" );
+      printf ( "Error: ops_timing_realloc error \n" );
       exit ( -1 );
     }
 

--- a/ops/c/src/core/ops_lib_core.c
+++ b/ops/c/src/core/ops_lib_core.c
@@ -641,8 +641,8 @@ ops_arg ops_arg_dat_core ( ops_dat dat, ops_stencil stencil, ops_access acc ) {
   arg.argtype = OPS_ARG_DAT;
   arg.dat = dat;
   arg.stencil = stencil;
-  if (acc != OPS_READ && stencil->points != 1) {
-    printf("Error: OPS does not support OPS_WRITE/OPS_RW/OPS_INC arguments with a non (0,0,0) stencil due to potential race conditions\n");
+  if (acc == OPS_WRITE && stencil->points != 1) {
+    printf("Error: OPS does not support OPS_WRITE arguments with a non (0,0,0) stencil due to potential race conditions\n");
     exit(-1);
   }
   if ( dat != NULL ) {

--- a/ops/c/src/cuda/ops_cuda_decl.c
+++ b/ops/c/src/cuda/ops_cuda_decl.c
@@ -222,7 +222,10 @@ void ops_halo_transfer(ops_halo_group group) {
         }
       }
     }*/
-
+    if (halo->from->dirty_hd == 1) {
+      ops_upload_dat(halo->from);
+      halo->from->dirty_hd = 0;
+    }
     ops_halo_copy_tobuf(ops_halo_buffer_d, 0, halo->from,
                        ranges[0], ranges[1],
                        ranges[2], ranges[3],
@@ -256,6 +259,10 @@ void ops_halo_transfer(ops_halo_group group) {
       }
     }*/
 
+    if (halo->to->dirty_hd == 1) {
+      ops_upload_dat(halo->to);
+      halo->to->dirty_hd = 0;
+    }
     ops_halo_copy_frombuf(halo->to, ops_halo_buffer_d, 0,
                    ranges[0], ranges[1],
                    ranges[2], ranges[3],

--- a/ops/c/src/cuda/ops_cuda_decl.c
+++ b/ops/c/src/cuda/ops_cuda_decl.c
@@ -51,7 +51,7 @@ void ops_init ( int argc, char ** argv, int diags )
   ops_init_core ( argc, argv, diags );
 
   if ((OPS_block_size_x*OPS_block_size_y) > 1024) {
-    printf ( " OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
+    printf ( "Error: OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
     exit ( -1 );
   }
 

--- a/ops/c/src/cuda/ops_cuda_rt_support.c
+++ b/ops/c/src/cuda/ops_cuda_rt_support.c
@@ -89,7 +89,7 @@ void cutilDeviceInit( int argc, char ** argv )
   int deviceCount;
   cutilSafeCall( cudaGetDeviceCount ( &deviceCount ) );
   if ( deviceCount == 0 ) {
-    printf ( "cutil error: no devices supporting CUDA\n" );
+    printf ( "Error: cutil error: no devices supporting CUDA\n" );
     exit ( -1 );
   }
 

--- a/ops/c/src/externlib/ops_checkpointing.c
+++ b/ops/c/src/externlib/ops_checkpointing.c
@@ -120,7 +120,7 @@ char *params;
 #define check_hdf5_error(err)           __check_hdf5_error      (err, __FILE__, __LINE__)
 void __check_hdf5_error(herr_t err, const char *file, const int line) {
   if (err < 0) {
-    printf("%s(%i) : OPS_HDF5_error() Runtime API error %d.%s\n", file, line, (int)err,params);
+    printf("Error: %s(%i) : OPS_HDF5_error() Runtime API error %d.%s\n", file, line, (int)err,params);
       exit(-1);
   }
 }
@@ -139,7 +139,7 @@ void ops_create_lock(char *fname) {
   if (FILE *lock = fopen(buffer,"w+")) {
     fclose(lock);
   } else {
-    if (OPS_diags>2) printf("Warning, lock file already exists\n");
+    if (OPS_diags>2) printf("Warning: lock file already exists\n");
   }
 }
 
@@ -149,7 +149,7 @@ void ops_create_lock_done(char *fname) {
   if (FILE *lock = fopen(buffer,"w+")) {
     fclose(lock);
   } else {
-    if (OPS_diags>2) printf("Warning, lock done file already exists\n");
+    if (OPS_diags>2) printf("Warning: lock done file already exists\n");
   }
 }
 
@@ -273,7 +273,7 @@ void ops_ramdisk_init(long size) {
   ops_ramdisk_item_queue_size = 3*OPS_dat_index;
   ops_ramdisk_initialised = 1;
   int rc = pthread_create(&thread, NULL, ops_saver_thread, NULL);
-  if (rc) {printf("ERROR; return code from pthread_create() is %d\n", rc); exit(-1);}
+  if (rc) {printf("Error: return code from pthread_create() is %d\n", rc); exit(-1);}
 }
 
 void ops_ramdisk_queue(ops_dat dat, hid_t outfile, int size, int *saved_range, char*data, int partial) {
@@ -364,7 +364,7 @@ void save_to_hdf5_full(ops_dat dat, hid_t outfile, int size, char *data) {
   } else if (strcmp(dat->type,"double")==0) {
     check_hdf5_error(H5LTmake_dataset(outfile, dat->name, 1, dims, H5T_NATIVE_DOUBLE, data));
   } else {
-    printf("Unsupported data type in ops_arg_dat() %s\n", dat->name);
+    printf("Error: Unsupported data type in ops_arg_dat() %s\n", dat->name);
     exit(-1);
   }
   ops_timers_core(&c1, &t2);
@@ -384,7 +384,7 @@ void save_to_hdf5_partial(ops_dat dat, hid_t outfile, int size, int *saved_range
   } else if (strcmp(dat->type,"double")==0) {
     check_hdf5_error(H5LTmake_dataset(outfile, dat->name, 1, dims, H5T_NATIVE_DOUBLE, data));
   } else {
-    printf("Unsupported data type in ops_arg_dat() %s\n", dat->name);
+    printf("Error: Unsupported data type in ops_arg_dat() %s\n", dat->name);
     exit(-1);
   }
 
@@ -535,7 +535,7 @@ void ops_restore_dataset(ops_dat dat) {
     } else if (strcmp(dat->type,"double")==0) {
       check_hdf5_error(H5LTread_dataset (file,  dat->name, H5T_NATIVE_DOUBLE, dat->data));
     } else {
-      printf("Unsupported data type in ops_arg_dat() %s\n",  dat->name);
+      printf("Error: Unsupported data type in ops_arg_dat() %s\n",  dat->name);
       exit(-1);
     }
     dat->dirty_hd = 1;
@@ -577,7 +577,7 @@ void ops_restore_dataset(ops_dat dat) {
     } else if (strcmp(dat->type,"double")==0) {
       check_hdf5_error(H5LTread_dataset (file,  dat->name, H5T_NATIVE_DOUBLE, OPS_partial_buffer));
     } else {
-      printf("Unsupported data type in ops_arg_dat() %s\n",  dat->name);
+      printf("Error: Unsupported data type in ops_arg_dat() %s\n",  dat->name);
       exit(-1);
     }
 
@@ -678,11 +678,11 @@ void ops_ctrldump(hid_t file_out) {
 
 void ops_chkp_sig_handler(int signo) {
   if (signo != SIGINT) {
-    printf("OPS received unknown signal %d\n",signo);
+    printf("Error: OPS received unknown signal %d\n",signo);
     return;
   }
   if (backup_state == OPS_BACKUP_IN_PROCESS) {
-    printf("ERROR: failed in checkpointing region, aborting checkpoint\n");
+    printf("Error: failed in checkpointing region, aborting checkpoint\n");
     return;
   }
   if (OPS_diags>1) printf("Process received SIGINT, dumping checkpoint from memory...\n");

--- a/ops/c/src/externlib/ops_hdf5.c
+++ b/ops/c/src/externlib/ops_hdf5.c
@@ -293,7 +293,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
   H5Pclose(plist_id);
 
   if(H5Lexists(file_id, block->name, H5P_DEFAULT) == 0) {
-	ops_printf("ops_fetch_dat_hdf5_file: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
+	ops_printf("Error: ops_fetch_dat_hdf5_file: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
 	exit(-2);
   }
   else {
@@ -315,7 +315,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
       else if(strcmp(dat->type,"long long") == 0)
          H5LTmake_dataset(group_id,dat->name,block->dims,G_SIZE,H5T_NATIVE_LLONG,dat->data);
     else {
-		  printf("Unknown type in ops_fetch_dat_hdf5_file()\n");
+		  printf("Error: Unknown type in ops_fetch_dat_hdf5_file()\n");
 		  exit(-2);
     }
 
@@ -349,8 +349,8 @@ ops_block ops_decl_block_hdf5(int dims, const char *block_name,
 
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
-    ops_printf("ops_decl_block_hdf5: File %s does not exist .... aborting\n", file_name);
-	exit(-2);
+    ops_printf("Error: ops_decl_block_hdf5: File %s does not exist .... aborting\n", file_name);
+	  exit(-2);
   }
 
   //Set up file access property list for I/O access
@@ -368,25 +368,25 @@ ops_block ops_decl_block_hdf5(int dims, const char *block_name,
     exit(-2);
   } else {
     if (strcmp("ops_block",read_ops_type) != 0) {
-      ops_printf("ops_decl_block_hdf5: ops_type of block %s is defined are not equal to ops_block.. Aborting\n",block_name);
+      ops_printf("Error: ops_decl_block_hdf5: ops_type of block %s is defined are not equal to ops_block.. Aborting\n",block_name);
       exit(-2);
     }
   }
   int read_dims;
   if (H5LTget_attribute_int(file_id, block_name, "dims", &read_dims) < 0) {
-    ops_printf("ops_decl_block_hdf5: Attribute \"dims\" not found in block %s .. Aborting\n",block_name);
+    ops_printf("Error: ops_decl_block_hdf5: Attribute \"dims\" not found in block %s .. Aborting\n",block_name);
     exit(-2);
   }
   else {
     if (dims != read_dims) {
-      ops_printf("ops_decl_block_hdf5: Unequal dims of block %s: dims on file %d, dims specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_block_hdf5: Unequal dims of block %s: dims on file %d, dims specified %d .. Aborting\n",
          block_name,read_dims, dims);
       exit(-2);
     }
   }
   int read_index;
   if (H5LTget_attribute_int(file_id, block_name, "index", &read_index) < 0) {
-    ops_printf("ops_decl_block_hdf5: Attribute \"index\" not found in block %s .. Aborting\n",block_name);
+    ops_printf("Error: ops_decl_block_hdf5: Attribute \"index\" not found in block %s .. Aborting\n",block_name);
     exit(-2);
   }
 
@@ -411,7 +411,7 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
 
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
-    ops_printf("ops_decl_stencil_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: File %s does not exist .... aborting\n", file_name);
     exit(-2);
   }
 
@@ -421,39 +421,39 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
 
   //check if ops_stencil exists
   if(H5Lexists(file_id, stencil_name, H5P_DEFAULT) == 0)
-    ops_printf("ops_decl_stencil_hdf5: ops_stencil %s does not exists in the file ... aborting\n", stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: ops_stencil %s does not exists in the file ... aborting\n", stencil_name);
 
   //ops_stencil exists .. now check ops_type and dims
   char read_ops_type[10];
   if (H5LTget_attribute_string(file_id, stencil_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"ops_type\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"ops_type\" not found in stencil %s .. Aborting\n",stencil_name);
     exit(-2);
   } else {
     if (strcmp("ops_stencil",read_ops_type) != 0) {
-      ops_printf("ops_decl_stencil_hdf5: ops_type of stencil %s is defined are not equal to ops_stencil.. Aborting\n",stencil_name);
+      ops_printf("Error: ops_decl_stencil_hdf5: ops_type of stencil %s is defined are not equal to ops_stencil.. Aborting\n",stencil_name);
       exit(-2);
     }
   }
   int read_dims;
   if (H5LTget_attribute_int(file_id, stencil_name, "dims", &read_dims) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"dims\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"dims\" not found in stencil %s .. Aborting\n",stencil_name);
     exit(-2);
   }
   else {
     if (dims != read_dims) {
-      ops_printf("ops_decl_stencil_hdf5: Unequal dims of stencil %s: dims on file %d, dims specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_stencil_hdf5: Unequal dims of stencil %s: dims on file %d, dims specified %d .. Aborting\n",
          stencil_name,read_dims, dims);
       exit(-2);
     }
   }
   int read_points;
   if (H5LTget_attribute_int(file_id, stencil_name, "points", &read_points) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"points\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"points\" not found in stencil %s .. Aborting\n",stencil_name);
     exit(-2);
   }
   else {
     if (points != read_points) {
-      ops_printf("ops_decl_stencil_hdf5: Unequal points of stencil %s: points on file %d, points specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_stencil_hdf5: Unequal points of stencil %s: points on file %d, points specified %d .. Aborting\n",
          stencil_name,read_points, points);
       exit(-2);
     }
@@ -463,7 +463,7 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
   //get the strides
   int read_stride[read_dims];
   if (H5LTget_attribute_int(file_id, stencil_name, "stride", read_stride) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"stride\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"stride\" not found in stencil %s .. Aborting\n",stencil_name);
     exit(-2);
   }
 
@@ -487,7 +487,7 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
 
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
-    ops_printf("ops_decl_halo_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_halo_hdf5: File %s does not exist .... aborting\n", file_name);
     exit(-2);
   }
 
@@ -499,23 +499,23 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
   char halo_name[100];//strlen(halo->from->name)+strlen(halo->to->name)];
   sprintf(halo_name, "from_%s_to_%s",from->name,to->name);
   if(H5Lexists(file_id, halo_name, H5P_DEFAULT) == 0)
-    ops_printf("ops_decl_halo_hdf5: ops_halo %s does not exists in the file ... aborting\n", halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: ops_halo %s does not exists in the file ... aborting\n", halo_name);
 
   //ops_stencil exists .. now check ops_type
   char read_ops_type[10];
   if (H5LTget_attribute_string(file_id, halo_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_halo_hdf5: Attribute \"ops_type\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: Attribute \"ops_type\" not found in halo %s .. Aborting\n",halo_name);
     exit(-2);
   } else {
     if (strcmp("ops_halo",read_ops_type) != 0) {
-      ops_printf("ops_decl_halo_hdf5: ops_type of halo %s defined are not equal to ops_halo.. Aborting\n",halo_name);
+      ops_printf("Error: ops_decl_halo_hdf5: ops_type of halo %s defined are not equal to ops_halo.. Aborting\n",halo_name);
       exit(-2);
     }
   }
 
   //check whether dimensions are equal
   if(from->block->dims != to->block->dims){
-    ops_printf("ops_decl_halo_hdf5: dimensions of ops_dats connected by halo %s are not equal to each other .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: dimensions of ops_dats connected by halo %s are not equal to each other .. Aborting\n",halo_name);
       exit(-2);
   }
   int dim = from->block->dims;
@@ -525,25 +525,25 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
   //get the iter_size
   int read_iter_size[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "iter_size", read_iter_size) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"iter_size\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"iter_size\" not found in halo %s .. Aborting\n",halo_name);
     exit(-2);
   }
   //get the from_base
   int read_from_base[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "from_base", read_from_base) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"from_base\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"from_base\" not found in halo %s .. Aborting\n",halo_name);
     exit(-2);
   }
   //get the to_base
   int read_to_base[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "to_base", read_to_base) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"to_base\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"to_base\" not found in halo %s .. Aborting\n",halo_name);
     exit(-2);
   }
   //get the from_dir
   int read_from_dir[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "from_dir", read_from_dir) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"from_dir\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"from_dir\" not found in halo %s .. Aborting\n",halo_name);
     exit(-2);
   }
   //get the to_dir
@@ -579,7 +579,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
 
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
-    ops_printf("ops_decl_dat_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_dat_hdf5: File %s does not exist .... aborting\n", file_name);
     exit(-2);
   }
 
@@ -588,7 +588,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
   file_id = H5Fopen(file_name, H5F_ACC_RDWR, plist_id);
 
   if(H5Lexists(file_id, block->name, H5P_DEFAULT) == 0) {
-      ops_printf("ops_decl_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat_name);
+      ops_printf("Error: ops_decl_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat_name);
       exit(-2);
   }
 
@@ -597,52 +597,52 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
 
   //check if ops_dat exists
   if(H5Lexists(group_id, dat_name, H5P_DEFAULT) == 0) {
-    ops_printf("ops_decl_dat_hdf5: ops_dat %s does not exists in the block %s ... aborting\n", dat_name, block->name);
+    ops_printf("Error: ops_decl_dat_hdf5: ops_dat %s does not exists in the block %s ... aborting\n", dat_name, block->name);
     exit(-2);
   }
 
   //ops_dat exists .. now check ops_type, block_index, type and dim
   char read_ops_type[10];
   if (H5LTget_attribute_string(group_id, dat_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_dat_hdf5: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   } else {
     if (strcmp("ops_dat",read_ops_type) != 0) {
-      ops_printf("ops_decl_dat_hdf5: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat_name);
+      ops_printf("Error: ops_decl_dat_hdf5: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat_name);
       exit(-2);
     }
   }
   int read_block_index;
   if (H5LTget_attribute_int(group_id, dat_name, "block_index", &read_block_index) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
   else {
     if (block->index != read_block_index) {
-      ops_printf("ops_decl_dat_hdf5: Unequal dims of data set %s: block index on file %d, block index specified for this dat %d .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Unequal dims of data set %s: block index on file %d, block index specified for this dat %d .. Aborting\n",
          dat_name,read_block_index, block->index);
       exit(-2);
     }
   }
   int read_dim;
   if (H5LTget_attribute_int(group_id, dat_name, "dim", &read_dim) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"dim\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"dim\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
   else {
     if (dat_dim != read_dim) {
-      ops_printf("ops_decl_dat_hdf5: Unequal dims of data set %s: dim on file %d, dim specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Unequal dims of data set %s: dim on file %d, dim specified %d .. Aborting\n",
          dat_name,read_dim, dat_dim);
       exit(-2);
     }
   }
   char read_type[15];
   if (H5LTget_attribute_string(group_id, dat_name, "type", read_type) < 0){
-    ops_printf("ops_decl_dat_hdf5: Attribute \"type\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"type\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   } else {
     if (strcmp(type,read_type) != 0) {
-      ops_printf("ops_decl_dat_hdf5: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
         dat_name, read_type, type);
       exit(-2);
     }
@@ -652,25 +652,25 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
 
   int read_size[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "size", read_size) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"size\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"size\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
 
   int read_d_m[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "d_m", read_d_m) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
 
   int read_d_p[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "d_p", read_d_p) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
 
   int read_base[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "base", read_base) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"base\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"base\" not found in data set %s .. Aborting\n",dat_name);
     exit(-2);
   }
 
@@ -687,7 +687,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
   else if(strcmp(read_type,"long long") == 0)
     type_size = sizeof(long long);
   else{
-    printf("Unknown type %s in ops_decl_dat_hdf5()\n", read_type);
+    printf("Error: Unknown type %s in ops_decl_dat_hdf5()\n", read_type);
     exit(2);
   }
 
@@ -709,7 +709,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
     else if(strcmp(read_type,"long long") == 0)
       H5LTread_dataset(group_id, dat_name, H5T_NATIVE_LLONG, data);
     else {
-      printf("Unknown type in ops_decl_dat_hdf5()\n");
+      printf("Error: Unknown type in ops_decl_dat_hdf5()\n");
       exit(-2);
   }
 

--- a/ops/c/src/mpi/ops_mpi_core.c
+++ b/ops/c/src/mpi/ops_mpi_core.c
@@ -192,7 +192,7 @@ ops_reduction ops_decl_reduction_handle(int size, const char *type, const char *
 
   ops_reduction red = ops_decl_reduction_handle_core(size, type, name);
   if (OPS_block_index < 1) {
-    printf("ops_decl_reduction_handle() should only be called after \
+    printf("Error: ops_decl_reduction_handle() should only be called after \
       declaring at least one ops_block\n -- Aborting\n");
     MPI_Abort(OPS_MPI_GLOBAL, 2);
   }

--- a/ops/c/src/mpi/ops_mpi_decl_cuda.c
+++ b/ops/c/src/mpi/ops_mpi_decl_cuda.c
@@ -53,7 +53,7 @@ void ops_init_cuda ( int argc, char ** argv, int diags )
   ops_init_core ( argc, argv, diags );
 
   if ((OPS_block_size_x*OPS_block_size_y) > 1024) {
-    printf ( " OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
+    printf ( "Error: OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
     exit ( -1 );
   }
 

--- a/ops/c/src/mpi/ops_mpi_decl_opencl.c
+++ b/ops/c/src/mpi/ops_mpi_decl_opencl.c
@@ -53,7 +53,7 @@ void ops_init_opencl ( int argc, char ** argv, int diags )
   ops_init_core ( argc, argv, diags );
 
   if ((OPS_block_size_x*OPS_block_size_y) > 1024) {
-    printf ( " OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
+    printf ( "Error: OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
     exit ( -1 );
   }
   for ( int n = 1; n < argc; n++ )

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -579,7 +579,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
     H5Pclose(plist_id);
 
     if(H5Lexists(file_id, block->name, H5P_DEFAULT) == 0) {
-      ops_printf("ops_fetch_dat_hdf5_file: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
+      ops_printf("Error: ops_fetch_dat_hdf5_file: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
     else {
@@ -637,7 +637,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
           dset_id = H5Dcreate(group_id, dat->name, H5T_NATIVE_LLONG, filespace,
           H5P_DEFAULT, plist_id, H5P_DEFAULT);
         else {
-          printf("Unknown type in ops_fetch_dat_hdf5_file()\n");
+          printf("Error: Unknown type in ops_fetch_dat_hdf5_file()\n");
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
         H5Pclose(plist_id);
@@ -664,34 +664,34 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
       //
       char read_ops_type[10];
       if (H5LTget_attribute_string(group_id, dat->name, "ops_type", read_ops_type) < 0){
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       } else {
         if (strcmp("ops_dat",read_ops_type) != 0) {
-          ops_printf("ops_fetch_dat_hdf5_file: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat->name);
+          ops_printf("Error: ops_fetch_dat_hdf5_file: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat->name);
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
       }
 
       char read_block_name[30];
       if (H5LTget_attribute_string(group_id, dat->name, "block", read_block_name) < 0){
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"block\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"block\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       } else {
         if (strcmp(block->name,read_block_name) != 0) {
-          ops_printf("ops_fetch_dat_hdf5_file: BLocks on which data set %s is defined are not equal .. Aborting\n",dat->name);
+          ops_printf("Error: ops_fetch_dat_hdf5_file: BLocks on which data set %s is defined are not equal .. Aborting\n",dat->name);
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
       }
 
       int read_block_index;
       if (H5LTget_attribute_int(group_id, dat->name, "block_index", &read_block_index) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         if (block->index != read_block_index) {
-          ops_printf("ops_fetch_dat_hdf5_file: Unequal dims of data set %s: block index on file %d, block index to be wirtten %d .. Aborting\n",
+          ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal dims of data set %s: block index on file %d, block index to be wirtten %d .. Aborting\n",
              dat->name,read_block_index, block->index);
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
@@ -699,12 +699,12 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       int read_dim;
       if (H5LTget_attribute_int(group_id, dat->name, "dim", &read_dim) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"dim\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"dim\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         if (dat->dim != read_dim) {
-          ops_printf("ops_fetch_dat_hdf5_file: Unequal dims of data set %s: dim on file %d, dim to be wirtten %d .. Aborting\n",
+          ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal dims of data set %s: dim on file %d, dim to be wirtten %d .. Aborting\n",
              dat->name,read_dim, dat->dim);
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
@@ -712,13 +712,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       int read_size[block->dims];
       if (H5LTget_attribute_int(group_id, dat->name, "size", read_size) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"size\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"size\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         for(int d = 0; d<block->dims; d++) {
           if (g_size[d] != read_size[d]) {
-            ops_printf("ops_fetch_dat_hdf5_file: Unequal sizes of data set %s: size[%d] on file %d, size[%d] to be wirtten %d .. Aborting\n",
+            ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal sizes of data set %s: size[%d] on file %d, size[%d] to be wirtten %d .. Aborting\n",
                dat->name, d, read_size[d], d, g_size[d]);
             MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
           }
@@ -727,13 +727,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       int read_d_m[block->dims];
       if (H5LTget_attribute_int(group_id, dat->name, "d_m", read_d_m) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         for(int d = 0; d<block->dims; d++) {
           if (g_d_m[d] != read_d_m[d]) {
-            ops_printf("ops_fetch_dat_hdf5_file: Unequal d_m of data set %s: g_d_m[%d] on file %d, g_d_m[%d] to be wirtten %d .. Aborting\n",
+            ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal d_m of data set %s: g_d_m[%d] on file %d, g_d_m[%d] to be wirtten %d .. Aborting\n",
                dat->name, d, read_d_m[d], d, g_d_m[d]);
             MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
           }
@@ -742,13 +742,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       int read_d_p[block->dims];
       if (H5LTget_attribute_int(group_id, dat->name, "d_p", read_d_p) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         for(int d = 0; d<block->dims; d++) {
           if (g_d_p[d] != read_d_p[d]) {
-            ops_printf("ops_fetch_dat_hdf5_file: Unequal d_p of data set %s: g_d_p[%d] on file %d, g_d_p[%d] to be wirtten %d .. Aborting\n",
+            ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal d_p of data set %s: g_d_p[%d] on file %d, g_d_p[%d] to be wirtten %d .. Aborting\n",
                dat->name, d, read_d_p[d], d, g_d_p[d]);
             MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
           }
@@ -757,13 +757,13 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       int read_base[block->dims];
       if (H5LTget_attribute_int(group_id, dat->name, "base", read_base) < 0) {
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"base\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"base\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
       else {
         for(int d = 0; d<block->dims; d++) {
           if (dat->base[d] != read_base[d]) {
-            ops_printf("ops_fetch_dat_hdf5_file: Unequal base of data set %s: base[%d] on file %d, base[%d] to be wirtten %d .. Aborting\n",
+            ops_printf("Error: ops_fetch_dat_hdf5_file: Unequal base of data set %s: base[%d] on file %d, base[%d] to be wirtten %d .. Aborting\n",
                dat->name, d, read_base[d], d, dat->base[d]);
             MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
           }
@@ -772,11 +772,11 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
       char read_type[15];
       if (H5LTget_attribute_string(group_id, dat->name, "type", read_type) < 0){
-        ops_printf("ops_fetch_dat_hdf5_file: Attribute \"type\" not found in data set %s .. Aborting\n",dat->name);
+        ops_printf("Error: ops_fetch_dat_hdf5_file: Attribute \"type\" not found in data set %s .. Aborting\n",dat->name);
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       } else {
         if (strcmp(dat->type,read_type) != 0) {
-          ops_printf("ops_fetch_dat_hdf5_file: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
+          ops_printf("Error: ops_fetch_dat_hdf5_file: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
             dat->name, read_type, dat->type);
           MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
         }
@@ -833,7 +833,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
       else if(strcmp(dat->type,"long long") == 0)
         H5Dwrite(dset_id, H5T_NATIVE_LLONG, memspace, filespace, plist_id, data);
       else {
-        printf("Unknown type in ops_fetch_dat_hdf5_file()\n");
+        printf("Error: Unknown type in ops_fetch_dat_hdf5_file()\n");
         MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
       }
 
@@ -876,7 +876,7 @@ ops_block ops_decl_block_hdf5(int dims, const char *block_name,
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
     MPI_Barrier(MPI_COMM_WORLD);
-    ops_printf("ops_decl_block_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_block_hdf5: File %s does not exist .... aborting\n", file_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -887,34 +887,34 @@ ops_block ops_decl_block_hdf5(int dims, const char *block_name,
 
   //check if ops_block exists
   if(H5Lexists(file_id, block_name, H5P_DEFAULT) == 0)
-    ops_printf("ops_decl_block_hdf5: ops_block %s does not exists in the file ... aborting\n", block_name);
+    ops_printf("Error: ops_decl_block_hdf5: ops_block %s does not exists in the file ... aborting\n", block_name);
 
   //ops_block exists .. now check ops_type and dims
   char read_ops_type[10];
   if (H5LTget_attribute_string(file_id, block_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_block_hdf5: Attribute \"ops_type\" not found in block %s .. Aborting\n",block_name);
+    ops_printf("Error: ops_decl_block_hdf5: Attribute \"ops_type\" not found in block %s .. Aborting\n",block_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   } else {
     if (strcmp("ops_block",read_ops_type) != 0) {
-      ops_printf("ops_decl_block_hdf5: ops_type of block %s is defined are not equal to ops_block.. Aborting\n",block_name);
+      ops_printf("Error: ops_decl_block_hdf5: ops_type of block %s is defined are not equal to ops_block.. Aborting\n",block_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_dims;
   if (H5LTget_attribute_int(file_id, block_name, "dims", &read_dims) < 0) {
-    ops_printf("ops_decl_block_hdf5: Attribute \"dims\" not found in block %s .. Aborting\n",block_name);
+    ops_printf("Error: ops_decl_block_hdf5: Attribute \"dims\" not found in block %s .. Aborting\n",block_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   else {
     if (dims != read_dims) {
-      ops_printf("ops_decl_block_hdf5: Unequal dims of block %s: dims on file %d, dims specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_block_hdf5: Unequal dims of block %s: dims on file %d, dims specified %d .. Aborting\n",
          block_name,read_dims, dims);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_index;
   if (H5LTget_attribute_int(file_id, block_name, "index", &read_index) < 0) {
-    ops_printf("ops_decl_block_hdf5: Attribute \"index\" not found in block %s .. Aborting\n",block_name);
+    ops_printf("Error: ops_decl_block_hdf5: Attribute \"index\" not found in block %s .. Aborting\n",block_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -950,7 +950,7 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
     MPI_Barrier(MPI_COMM_WORLD);
-    ops_printf("ops_decl_stencil_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: File %s does not exist .... aborting\n", file_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -961,39 +961,39 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
 
   //check if ops_stencil exists
   if(H5Lexists(file_id, stencil_name, H5P_DEFAULT) == 0)
-    ops_printf("ops_decl_stencil_hdf5: ops_stencil %s does not exists in the file ... aborting\n", stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: ops_stencil %s does not exists in the file ... aborting\n", stencil_name);
 
   //ops_stencil exists .. now check ops_type and dims
   char read_ops_type[10];
   if (H5LTget_attribute_string(file_id, stencil_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"ops_type\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"ops_type\" not found in stencil %s .. Aborting\n",stencil_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   } else {
     if (strcmp("ops_stencil",read_ops_type) != 0) {
-      ops_printf("ops_decl_stencil_hdf5: ops_type of stencil %s is defined are not equal to ops_stencil.. Aborting\n",stencil_name);
+      ops_printf("Error: ops_decl_stencil_hdf5: ops_type of stencil %s is defined are not equal to ops_stencil.. Aborting\n",stencil_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_dims;
   if (H5LTget_attribute_int(file_id, stencil_name, "dims", &read_dims) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"dims\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"dims\" not found in stencil %s .. Aborting\n",stencil_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   else {
     if (dims != read_dims) {
-      ops_printf("ops_decl_stencil_hdf5: Unequal dims of stencil %s: dims on file %d, dims specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_stencil_hdf5: Unequal dims of stencil %s: dims on file %d, dims specified %d .. Aborting\n",
          stencil_name,read_dims, dims);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_points;
   if (H5LTget_attribute_int(file_id, stencil_name, "points", &read_points) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"points\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"points\" not found in stencil %s .. Aborting\n",stencil_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   else {
     if (points != read_points) {
-      ops_printf("ops_decl_stencil_hdf5: Unequal points of stencil %s: points on file %d, points specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_stencil_hdf5: Unequal points of stencil %s: points on file %d, points specified %d .. Aborting\n",
          stencil_name,read_points, points);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
@@ -1003,7 +1003,7 @@ ops_stencil ops_decl_stencil_hdf5(int dims, int points, const char *stencil_name
   //get the strides
   int read_stride[read_dims];
   if (H5LTget_attribute_int(file_id, stencil_name, "stride", read_stride) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"stride\" not found in stencil %s .. Aborting\n",stencil_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"stride\" not found in stencil %s .. Aborting\n",stencil_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1038,7 +1038,7 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
     MPI_Barrier(MPI_COMM_WORLD);
-    ops_printf("ops_decl_halo_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_halo_hdf5: File %s does not exist .... aborting\n", file_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1051,23 +1051,23 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
   char halo_name[100];//strlen(halo->from->name)+strlen(halo->to->name)];
   sprintf(halo_name, "from_%s_to_%s",from->name,to->name);
   if(H5Lexists(file_id, halo_name, H5P_DEFAULT) == 0)
-    ops_printf("ops_decl_halo_hdf5: ops_halo %s does not exists in the file ... aborting\n", halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: ops_halo %s does not exists in the file ... aborting\n", halo_name);
 
   //ops_stencil exists .. now check ops_type
   char read_ops_type[10];
   if (H5LTget_attribute_string(file_id, halo_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_halo_hdf5: Attribute \"ops_type\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: Attribute \"ops_type\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   } else {
     if (strcmp("ops_halo",read_ops_type) != 0) {
-      ops_printf("ops_decl_halo_hdf5: ops_type of halo %s defined are not equal to ops_halo.. Aborting\n",halo_name);
+      ops_printf("Error: ops_decl_halo_hdf5: ops_type of halo %s defined are not equal to ops_halo.. Aborting\n",halo_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
 
   //check whether dimensions are equal
   if(from->block->dims != to->block->dims){
-    ops_printf("ops_decl_halo_hdf5: dimensions of ops_dats connected by halo %s are not equal to each other .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_halo_hdf5: dimensions of ops_dats connected by halo %s are not equal to each other .. Aborting\n",halo_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   int dim = from->block->dims;
@@ -1077,31 +1077,31 @@ ops_halo ops_decl_halo_hdf5(ops_dat from, ops_dat to, char const *file_name) {
   //get the iter_size
   int read_iter_size[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "iter_size", read_iter_size) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"iter_size\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"iter_size\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   //get the from_base
   int read_from_base[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "from_base", read_from_base) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"from_base\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"from_base\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   //get the to_base
   int read_to_base[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "to_base", read_to_base) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"to_base\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"to_base\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   //get the from_dir
   int read_from_dir[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "from_dir", read_from_dir) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"from_dir\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"from_dir\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   //get the to_dir
   int read_to_dir[dim];
   if (H5LTget_attribute_int(file_id, halo_name, "to_dir", read_to_dir) < 0) {
-    ops_printf("ops_decl_stencil_hdf5: Attribute \"to_dir\" not found in halo %s .. Aborting\n",halo_name);
+    ops_printf("Error: ops_decl_stencil_hdf5: Attribute \"to_dir\" not found in halo %s .. Aborting\n",halo_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1142,7 +1142,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
   //open given hdf5 file .. if it exists
   if (file_exist(file_name) == 0) {
     MPI_Barrier(MPI_COMM_WORLD);
-    ops_printf("ops_decl_dat_hdf5: File %s does not exist .... aborting\n", file_name);
+    ops_printf("Error: ops_decl_dat_hdf5: File %s does not exist .... aborting\n", file_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1152,7 +1152,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
   file_id = H5Fopen(file_name, H5F_ACC_RDWR, plist_id);
 
   if(H5Lexists(file_id, block->name, H5P_DEFAULT) == 0) {
-      ops_printf("ops_decl_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat_name);
+      ops_printf("Error: ops_decl_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1161,52 +1161,52 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
 
   //check if ops_dat exists
   if(H5Lexists(group_id, dat_name, H5P_DEFAULT) == 0) {
-    ops_printf("ops_decl_dat_hdf5: ops_dat %s does not exists in the block %s ... aborting\n", dat_name, block->name);
+    ops_printf("Error: ops_decl_dat_hdf5: ops_dat %s does not exists in the block %s ... aborting\n", dat_name, block->name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
   //ops_dat exists .. now check ops_type, block_index, type and dim
   char read_ops_type[10];
   if (H5LTget_attribute_string(group_id, dat_name, "ops_type", read_ops_type) < 0){
-    ops_printf("ops_decl_dat_hdf5: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"ops_type\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   } else {
     if (strcmp("ops_dat",read_ops_type) != 0) {
-      ops_printf("ops_decl_dat_hdf5: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat_name);
+      ops_printf("Error: ops_decl_dat_hdf5: ops_type of dat %s is defined are not equal to ops_dat.. Aborting\n",dat_name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_block_index;
   if (H5LTget_attribute_int(group_id, dat_name, "block_index", &read_block_index) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"block_index\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   else {
     if (block->index != read_block_index) {
-      ops_printf("ops_decl_dat_hdf5: Unequal dims of data set %s: block index on file %d, block index specified for this dat %d .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Unequal dims of data set %s: block index on file %d, block index specified for this dat %d .. Aborting\n",
          dat_name,read_block_index, block->index);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   int read_dim;
   if (H5LTget_attribute_int(group_id, dat_name, "dim", &read_dim) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"dim\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"dim\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
   else {
     if (dat_dim != read_dim) {
-      ops_printf("ops_decl_dat_hdf5: Unequal dims of data set %s: dim on file %d, dim specified %d .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Unequal dims of data set %s: dim on file %d, dim specified %d .. Aborting\n",
          dat_name,read_dim, dat_dim);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
   }
   char read_type[15];
   if (H5LTget_attribute_string(group_id, dat_name, "type", read_type) < 0){
-    ops_printf("ops_decl_dat_hdf5: Attribute \"type\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"type\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   } else {
     if (strcmp(type,read_type) != 0) {
-      ops_printf("ops_decl_dat_hdf5: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
+      ops_printf("Error: ops_decl_dat_hdf5: Type of data of data set %s is not equal: type on file %s, type specified %s .. Aborting\n",
         dat_name, read_type, type);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
@@ -1216,25 +1216,25 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
 
   int read_size[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "size", read_size) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"size\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"size\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
   int read_d_m[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "d_m", read_d_m) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"d_m\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
   int read_d_p[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "d_p", read_d_p) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"d_p\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
   int read_base[block->dims];
   if (H5LTget_attribute_int(group_id, dat_name, "base", read_base) < 0) {
-    ops_printf("ops_decl_dat_hdf5: Attribute \"base\" not found in data set %s .. Aborting\n",dat_name);
+    ops_printf("Error: ops_decl_dat_hdf5: Attribute \"base\" not found in data set %s .. Aborting\n",dat_name);
     MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
   }
 
@@ -1251,7 +1251,7 @@ ops_dat ops_decl_dat_hdf5(ops_block block, int dat_dim,
   else if(strcmp(read_type,"long long") == 0)
     type_size = sizeof(long long);
   else{
-    printf("Unknown type %s in ops_decl_dat_hdf5()\n", read_type);
+    printf("Error: Unknown type %s in ops_decl_dat_hdf5()\n", read_type);
     exit(2);
   }
 
@@ -1372,7 +1372,7 @@ void ops_read_dat_hdf5(ops_dat dat) {
     //open given hdf5 file .. if it exists
     if (file_exist(dat->hdf5_file) == 0) {
       MPI_Barrier(MPI_COMM_WORLD);
-      ops_printf("ops_read_dat_hdf5: File %s does not exist .... aborting\n", dat->hdf5_file);
+      ops_printf("Error: ops_read_dat_hdf5: File %s does not exist .... aborting\n", dat->hdf5_file);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
 
@@ -1383,7 +1383,7 @@ void ops_read_dat_hdf5(ops_dat dat) {
     H5Pclose(plist_id);
 
     if(H5Lexists(file_id, block->name, H5P_DEFAULT) == 0) {
-      ops_printf("ops_read_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
+      ops_printf("Error: ops_read_dat_hdf5: ops_block on which this ops_dat %s is declared does not exists in the file ... Aborting\n", dat->name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
 
@@ -1392,7 +1392,7 @@ void ops_read_dat_hdf5(ops_dat dat) {
 
     //check if ops_dat exists
     if(H5Lexists(group_id, dat->name, H5P_DEFAULT) == 0){
-      ops_printf("ops_read_dat_hdf5: ops_dat %s does not exists in the ops_block %s... aborting\n",
+      ops_printf("Error: ops_read_dat_hdf5: ops_dat %s does not exists in the ops_block %s... aborting\n",
         dat->name, block->name);
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
@@ -1458,7 +1458,7 @@ void ops_read_dat_hdf5(ops_dat dat) {
     else if(strcmp(dat->type,"long long") == 0)
       H5Dread(dset_id, H5T_NATIVE_LLONG, memspace, filespace, plist_id, data);
     else {
-      printf("Unknown type in ops_read_dat_hdf5()\n");
+      printf("Error: Unknown type in ops_read_dat_hdf5()\n");
       MPI_Abort(OPS_MPI_HDF5_WORLD, 2);
     }
 

--- a/ops/c/src/mpi/ops_mpi_rt_support.c
+++ b/ops/c/src/mpi/ops_mpi_rt_support.c
@@ -1101,5 +1101,4 @@ void ops_halo_transfer(ops_halo_group group) {
     }
   }
   MPI_Waitall(mpi_group->num_neighbors_send,&mpi_group->requests[0],&mpi_group->statuses[0]);
-  //TODO: host/device dirtybits???
 }

--- a/ops/c/src/mpi/ops_mpi_rt_support.c
+++ b/ops/c/src/mpi/ops_mpi_rt_support.c
@@ -185,7 +185,7 @@ void ops_exchange_halo2(ops_arg* arg, int* d_pos, int* d_neg /*depth*/)
         MPI_Sendrecv(&actual_depth,1,MPI_INT,sb->id_p[n],666,
           &they_send,1,MPI_INT,sb->id_m[n],666,sb->comm, &status);
         if (sb->id_m[n]>=0 && actual_depth != they_send) {
-          printf("Left recv mismatch\n");
+          printf("Error: Left recv mismatch\n");
           MPI_Abort(sb->comm,-1);
         }
       }
@@ -222,7 +222,7 @@ void ops_exchange_halo2(ops_arg* arg, int* d_pos, int* d_neg /*depth*/)
         MPI_Sendrecv(&actual_depth,1,MPI_INT,sb->id_m[n],665,
           &they_send,1,MPI_INT,sb->id_p[n],665,sb->comm, &status);
         if (sb->id_p[n]>=0 && actual_depth != they_send) {
-          printf("Right recv mismatch\n");
+          printf("Error: Right recv mismatch\n");
           MPI_Abort(sb->comm,-1);
         }
       }
@@ -347,7 +347,7 @@ void ops_exchange_halo3(ops_arg* arg, int* d_pos, int* d_neg /*depth*/, int *ite
       MPI_Sendrecv(&actual_depth_send,1,MPI_INT,sb->id_m[dim],665,
         &they_send,1,MPI_INT,sb->id_p[dim],665,sb->comm, &status);
       if (sb->id_p[dim]>=0 && actual_depth_recv != they_send) {
-        printf("\nRight recv mismatch: expecting %d receiving %d\n",actual_depth_recv, they_send);
+        printf("\nError: Right recv mismatch: expecting %d receiving %d\n",actual_depth_recv, they_send);
         MPI_Abort(sb->comm,-1);
       }
     }
@@ -393,7 +393,7 @@ void ops_exchange_halo3(ops_arg* arg, int* d_pos, int* d_neg /*depth*/, int *ite
       MPI_Sendrecv(&actual_depth_send,1,MPI_INT,sb->id_p[dim],666,
         &they_send,1,MPI_INT,sb->id_m[dim],666,sb->comm, &status);
       if (sb->id_m[dim]>=0 && actual_depth_recv != they_send) {
-        printf("\nLeft recv mismatch: expecting %d receiving %d\n",actual_depth_recv, they_send);
+        printf("\nError: Left recv mismatch: expecting %d receiving %d\n",actual_depth_recv, they_send);
         MPI_Abort(sb->comm,-1);
       }
     }
@@ -503,7 +503,7 @@ void ops_exchange_halo_packer(ops_dat dat, int d_pos, int d_neg, int *iter_range
     MPI_Sendrecv(&actual_depth_send,1,MPI_INT,sb->id_m[dim],665,
       &they_send,1,MPI_INT,sb->id_p[dim],665,sb->comm, &status);
     if (sb->id_p[dim]>=0 && actual_depth_recv != they_send) {
-      printf("Right recv mismatch\n");
+      printf("Error: Right recv mismatch\n");
       MPI_Abort(sb->comm,-1);
     }
   }
@@ -560,7 +560,7 @@ void ops_exchange_halo_packer(ops_dat dat, int d_pos, int d_neg, int *iter_range
     MPI_Sendrecv(&actual_depth_send,1,MPI_INT,sb->id_p[dim],666,
       &they_send,1,MPI_INT,sb->id_m[dim],666,sb->comm, &status);
     if (sb->id_m[dim]>=0 && actual_depth_recv != they_send) {
-      printf("Left recv mismatch\n");
+      printf("Error: Left recv mismatch\n");
       MPI_Abort(sb->comm,-1);
     }
   }

--- a/ops/c/src/mpi/ops_mpi_rt_support_cuda.cu
+++ b/ops/c/src/mpi/ops_mpi_rt_support_cuda.cu
@@ -256,6 +256,11 @@ void ops_halo_copy_tobuf(char * dest, int dest_offset,
     gpu_ptr = halo_buffer_d;
   }
 
+  if (src->dirty_hd == 1) {
+    ops_upload_dat(src);
+    src->dirty_hd = 0;
+  }
+
   dim3 grid(blk_x,blk_y,blk_z);
   dim3 tblock(thr_x,thr_y,thr_z);
   copy_kernel_tobuf<<<grid, tblock>>>(gpu_ptr, src->data_d,
@@ -309,6 +314,11 @@ void ops_halo_copy_frombuf(ops_dat dest,
     }
     gpu_ptr = halo_buffer_d;
     cutilSafeCall(cudaMemcpy(halo_buffer_d, src, size*sizeof(char), cudaMemcpyHostToDevice));
+  }
+  
+  if (dest->dirty_hd == 1) {
+    ops_upload_dat(dest);
+    dest->dirty_hd = 0;
   }
 
   dim3 grid(blk_x,blk_y,blk_z);

--- a/ops/c/src/mpi/ops_mpi_rt_support_opencl.cpp
+++ b/ops/c/src/mpi/ops_mpi_rt_support_opencl.cpp
@@ -583,6 +583,11 @@ void ops_halo_copy_tobuf(char * dest, int dest_offset,
   }
   cl_mem gpu_ptr = halo_buffer_d2;
 
+  if (src->dirty_hd == 1) {
+    ops_upload_dat(src);
+    src->dirty_hd = 0;
+  }
+
   size_t globalWorkSize[3] = {blk_x*thr_x, blk_y*thr_y, blk_z*thr_z};
   size_t localWorkSize[3] =  {thr_x, thr_y, thr_z};
 
@@ -692,6 +697,11 @@ void ops_halo_copy_frombuf(ops_dat dest,
     halo_buffer_size2 = size;
   }
   gpu_ptr = halo_buffer_d2;
+
+  if (dest->dirty_hd == 1) {
+    ops_upload_dat(dest);
+    dest->dirty_hd = 0;
+  }
 
   size_t globalWorkSize[3] = {blk_x*thr_x, blk_y*thr_y, blk_z*thr_z};
   size_t localWorkSize[3] =  {thr_x, thr_y, thr_z};

--- a/ops/c/src/opencl/ops_opencl_decl.c
+++ b/ops/c/src/opencl/ops_opencl_decl.c
@@ -56,7 +56,7 @@ void ops_init ( int argc, char ** argv, int diags )
   ops_init_core ( argc, argv, diags );
 
   if ((OPS_block_size_x*OPS_block_size_y) > 1024) {
-    printf ( " OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
+    printf ( "Error: OPS_block_size_x*OPS_block_size_y should be less than 1024 -- error OPS_block_size_*\n" );
     exit ( -1 );
   }
   for ( int n = 1; n < argc; n++ )

--- a/ops/c/src/opencl/ops_opencl_rt_support.c
+++ b/ops/c/src/opencl/ops_opencl_rt_support.c
@@ -143,7 +143,7 @@ char *clGetErrorString(cl_int err) {
 
 void __clSafeCall(cl_int ret, const char * file, const int line) {
   if ( CL_SUCCESS != ret ) {
-    ops_fprintf ( stderr, "%s(%i) : clSafeCall() Runtime API error : %s.\n",
+    ops_fprintf ( stderr, "Error: %s(%i) : clSafeCall() Runtime API error : %s.\n",
         file, line, clGetErrorString ( ret ) );
     exit ( -1 );
   }

--- a/ops/fortran/Makefile
+++ b/ops/fortran/Makefile
@@ -27,11 +27,11 @@ ifndef NV_ARCH
 endif
 ifeq ($(NV_ARCH),Fermi)
   CODE_GEN_CUDA=-gencode arch=compute_20,code=sm_21
-  PGI_CUDA_FORT_FLAGS=-Mcuda=cuda5.5,cc20
+  PGI_CUDA_FORT_FLAGS=-Mcuda=cuda7.0,cc20
 else
 ifeq ($(NV_ARCH),Kepler)
   CODE_GEN_CUDA=-gencode arch=compute_35,code=sm_35
-  PGI_CUDA_FORT_FLAGS=-Mcuda=cuda6.0,cc35
+  PGI_CUDA_FORT_FLAGS=-Mcuda=cuda7.0,cc35
 endif
 endif
 

--- a/translator/python/c/ops_gen_mpi_openacc.py
+++ b/translator/python/c/ops_gen_mpi_openacc.py
@@ -150,7 +150,7 @@ def ops_gen_mpi_openacc(master, date, consts, kernels):
 
     code('#include "./OpenACC/'+master.split('.')[0]+'_common.h"')
     code('')
-    if not (('generate_chunk' in name) or ('calc_dt_kernel_print' in name)):
+    if not (('calc_dt_kernel_print' in name)):
       if not (NDIM==3 and 'field_summary' in name):
         code('#define OPS_GPU')
         code('')
@@ -462,7 +462,7 @@ def ops_gen_mpi_openacc(master, date, consts, kernels):
 
     code('#include "./OpenACC/'+master.split('.')[0]+'_common.h"')
     code('')
-    if not (('generate_chunk' in name) or ('calc_dt_kernel_print' in name)):
+    if not (('calc_dt_kernel_print' in name)):
       if not (NDIM==3 and 'field_summary' in name):
         code('#define OPS_GPU')
         code('')

--- a/translator/python/fortran/ops_fortran_gen_mpi_cuda.py
+++ b/translator/python/fortran/ops_fortran_gen_mpi_cuda.py
@@ -555,9 +555,9 @@ def ops_fortran_gen_mpi_cuda(master, date, consts, kernels):
         if accs[n] == OPS_INC:
           code('opsGblDat'+str(n+1)+'Device = 0.0_8')
         if accs[n] == OPS_MIN:
-          code('opsGblDat'+str(n+1)+'Device = 0.0d')
+          code('opsGblDat'+str(n+1)+'Device = HUGE(opsGblDat'+str(n+1)+'Device)')
         if accs[n] == OPS_MAX:
-          code('opsGblDat'+str(n+1)+'Device = 0.0d')
+          code('opsGblDat'+str(n+1)+'Device = -1.0_8*HUGE(opsGblDat'+str(n+1)+'Device)')
 
     if NDIM==1:
       IF('(n_x-1) < size1')

--- a/translator/python/fortran/ops_fortran_gen_mpi_cuda.py
+++ b/translator/python/fortran/ops_fortran_gen_mpi_cuda.py
@@ -60,6 +60,8 @@ ENDIF = util_fortran.ENDIF
 const_list = []
 def replace_consts(text):
   global const_list
+  if not os.path.isfile("constants_list.txt"):
+    return text
   fi2 = open("constants_list.txt","r")
   for line in fi2:
     fstr = '\\b'+line[:-1]+'\\b'

--- a/translator/python/fortran/ops_fortran_gen_mpi_openmp.py
+++ b/translator/python/fortran/ops_fortran_gen_mpi_openmp.py
@@ -137,12 +137,17 @@ def ops_fortran_gen_mpi_openmp(master, date, consts, kernels):
     for n in range (0, nargs):
       if arg_typ[n] == 'ops_arg_dat':
         if int(dims[n]) == 1:
-          code('INTEGER(KIND=4) xdim'+str(n+1))
           if NDIM==1:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
             code('#define OPS_ACC'+str(n+1)+'(x) (x+1)')
           if NDIM==2:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
+            code('INTEGER(KIND=4) ydim'+str(n+1))
             code('#define OPS_ACC'+str(n+1)+'(x,y) (x+xdim'+str(n+1)+'*(y)+1)')
           if NDIM==3:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
+            code('INTEGER(KIND=4) ydim'+str(n+1))
+            code('INTEGER(KIND=4) zdim'+str(n+1))
             code('#define OPS_ACC'+str(n+1)+'(x,y,z) (x+xdim'+str(n+1)+'*(y)+xdim'+str(n+1)+'*ydim'+str(n+1)+'*(z)+1)')
     code('')
 
@@ -150,12 +155,17 @@ def ops_fortran_gen_mpi_openmp(master, date, consts, kernels):
       if arg_typ[n] == 'ops_arg_dat':
         if int(dims[n]) > 1:
           code('INTEGER(KIND=4) multi_d'+str(n+1))
-          code('INTEGER(KIND=4) xdim'+str(n+1))
           if NDIM==1:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
             code('#define OPS_ACC_MD'+str(n+1)+'(d,x) ((x)*'+str(dims[n])+'+(d))')
           if NDIM==2:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
+            code('INTEGER(KIND=4) ydim'+str(n+1))
             code('#define OPS_ACC_MD'+str(n+1)+'(d,x,y) ((x)*'+str(dims[n])+'+(d)+(xdim'+str(n+1)+'*(y)*'+str(dims[n])+'))')
           if NDIM==3:
+            code('INTEGER(KIND=4) xdim'+str(n+1))
+            code('INTEGER(KIND=4) ydim'+str(n+1))
+            code('INTEGER(KIND=4) zdim'+str(n+1))
             code('#define OPS_ACC_MD'+str(n+1)+'(d,x,y,z) ((x)*'+str(dims[n])+'+(d)+(xdim'+str(n+1)+'*(y)*'+str(dims[n])+')+(xdim'+str(n+1)+'*ydim'+str(n+1)+'*(z)*'+str(dims[n])+'))')
 
     code('')
@@ -240,7 +250,7 @@ def ops_fortran_gen_mpi_openmp(master, date, consts, kernels):
     if NDIM==1:
       if reduction <> 1 and arg_idx <> 1:
         code('!$OMP PARALLEL DO')
-        code('!DIR$ SIMD')
+        code('!DIR$ IVDEP')
       elif reduction == 1:
         code('!$OMP PARALLEL DO '+reduction_vars)
       DO('n_x','1','end(1)-start(1)+1')
@@ -255,7 +265,7 @@ def ops_fortran_gen_mpi_openmp(master, date, consts, kernels):
       DO('n_y','1','end(2)-start(2)+1')
       if arg_idx == 1:
         code('idx_local(2) = idx(2) + n_y - 1')
-      code('!DIR$ SIMD')
+      code('!DIR$ IVDEP')
       DO('n_x','1','end(1)-start(1)+1')
       if arg_idx == 1:
         code('idx_local(1) = idx(1) + n_x - 1')
@@ -271,7 +281,7 @@ def ops_fortran_gen_mpi_openmp(master, date, consts, kernels):
       DO('n_y','1','end(2)-start(2)+1')
       if arg_idx == 1:
         code('idx_local(2) = idx(2) + n_y - 1')
-      code('!DIR$ SIMD')
+      code('!DIR$ IVDEP')
       DO('n_x','1','end(1)-start(1)+1')
       if arg_idx == 1:
         code('idx_local(1) = idx(1) + n_x - 1')


### PR DESCRIPTION
Pulls in a number of fixes for Fortran and 3D support, including finding functions called from within user kernels in Fortran CUDA. I have also added checks for non-0 point stencils that are written and which are invalid according to the OPS abstraction. However, this breaks CloverLeaf's generate_chunk - it has to be reformulated.