### PR TITLE
Pull request for a minor fix in the ops C translator 

### DIFF
--- a/translator/python/c/ops_gen_mpi_inline.py
+++ b/translator/python/c/ops_gen_mpi_inline.py
@@ -41,6 +41,7 @@ plus a master kernel file
 import re
 import datetime
 import os
+import glob
 
 import util
 import config
@@ -185,7 +186,20 @@ def ops_gen_mpi_inline(master, date, consts, kernels):
 ##########################################################################
 
     comm('user function')
-    fid = open(name2+'_kernel.h', 'r')
+    found = 0
+    for files in glob.glob( "*.h" ):
+      f = open( files, 'r' )
+      for line in f:
+        if name in line:
+          file_name = f.name
+          found = 1;
+          break
+      if found == 1:
+        break;
+
+    if found == 0:
+      print "COUND NOT FIND KERNEL", name
+    fid = open(file_name, 'r')
     text = fid.read()
     fid.close()
     text = comment_remover(text)


### PR DESCRIPTION
Modified ops_gen_mpi_inline.py similar to mpi and CUDA. This allows multiple kernels to be written to the same *.h file.
This is modified as our code is failing to translate when using the translator in the current master branch