### PR TITLE
Fix an issue when exporting MultiDim data to HDF5  in the parallel mode.

### DIFF
--- a/apps/c/TeaLeaf/Makefile
+++ b/apps/c/TeaLeaf/Makefile
@@ -41,9 +41,8 @@ ifeq ($(OPS_COMPILER),intel)
 ifdef DEBUG
   CCFLAGS	= -O0 -g -fp-model strict -fp-model source -prec-div -prec-sqrt -DMPICH_IGNORE_CXX_SEEK #-DOPS_DEBUG
 else
-  CCFLAGS	= -O3 -ipo -fp-model strict -fp-model source -prec-div -prec-sqrt -vec-report2 -xHost -parallel #-DCOMM_PERF #-DDEBUG
-  #CCFLAGS	= -O3 -g -no-prec-div -xHost -parallel -fma #-DCOMM_PERF #-DDEBUG
-  #CCFLAGS	= -O3 -no-prec-div -restrict -fno-alias -xHost -fma -fp-model fast=2 #-fp-model strict -fp-model source -prec-div -prec-sqrt -DMPICH_IGNORE_CXX_SEEK -qopt-report #-qopt-report=5 # -vec-report
+  CCFLAGS	= -O3 -ipo -fp-model strict -fp-model source -no-prec-div -prec-sqrt -vec-report2 -xHost -parallel -restrict -fno-alias -inline-forceinline #-DCOMM_PERF #-DDEBUG
+  #CCFLAGS	= -O3 -no-prec-div -ip  -fp-model strict -fp-model source -prec-div -prec-sqrt
 endif
   CPPFLAGS	= $(CCFLAGS)
   OMPFLAGS	= -qopenmp #-openmp-report2
@@ -151,7 +150,7 @@ OCL_FLAGS=#-DOCL_FMA_SWITCH_ON
 # master to make all versions
 #
 
-TARGETS = tealeaf_dev_seq tealeaf_dev_mpi tealeaf_mpi tealeaf_mpi_openmp tealeaf_openmp tealeaf_seq tealeaf_tiled tealeaf_cuda tealeaf_mpi_cuda tealeaf_opencl tealeaf_mpi_opencl #tealeaf_openacc tealeaf_mpi_openacc
+TARGETS = tealeaf_dev_seq tealeaf_dev_mpi tealeaf_mpi tealeaf_mpi_openmp tealeaf_openmp tealeaf_seq tealeaf_tiled tealeaf_cuda tealeaf_mpi_cuda tealeaf_opencl tealeaf_mpi_opencl tealeaf_mpi_tiled #tealeaf_openacc tealeaf_mpi_openacc
 
 ifeq ($(OPS_COMPILER),pgi)
 TARGETS += tealeaf_openacc tealeaf_mpi_openacc

--- a/apps/c/TeaLeaf/test.sh
+++ b/apps/c/TeaLeaf/test.sh
@@ -58,6 +58,15 @@ grep "PASSED" tea.out
 rc=$?; if [[ $rc != 0 ]]; then echo "TEST FAILED";exit $rc; fi
 rm -f tea.out
 
+echo '============> Running MPI_Tiled'
+export OMP_NUM_THREADS=10;$MPI_INSTALL_PATH/bin/mpirun -np 2 ./cloverleaf_mpi_tiled OPS_TILING OPS_TILING_MAXDEPTH=6 > perf_out
+grep "Total Wall time" tea.out
+grep -e "step:    86" -e "step:    87" -e "step:    88"  tea.out
+grep "PASSED" tea.out
+rc=$?; if [[ $rc != 0 ]]; then echo "TEST FAILED";exit $rc; fi
+rm -f tea.out
+
+
 #echo '============> Running MPI_Inline'
 #export OMP_NUM_THREADS=1;$MPI_INSTALL_PATH/bin/mpirun -np 20 ./tealeaf_mpi_inline > perf_out
 #grep "Total Wall time" tea.out

--- a/apps/c/TeaLeaf/test.sh
+++ b/apps/c/TeaLeaf/test.sh
@@ -59,7 +59,7 @@ rc=$?; if [[ $rc != 0 ]]; then echo "TEST FAILED";exit $rc; fi
 rm -f tea.out
 
 echo '============> Running MPI_Tiled'
-export OMP_NUM_THREADS=10;$MPI_INSTALL_PATH/bin/mpirun -np 2 ./cloverleaf_mpi_tiled OPS_TILING OPS_TILING_MAXDEPTH=6 > perf_out
+export OMP_NUM_THREADS=10;$MPI_INSTALL_PATH/bin/mpirun -np 2 ./tealeaf_mpi_tiled OPS_TILING OPS_TILING_MAXDEPTH=6 > perf_out
 grep "Total Wall time" tea.out
 grep -e "step:    86" -e "step:    87" -e "step:    88"  tea.out
 grep "PASSED" tea.out

--- a/ops/c/src/externlib/ops_hdf5.c
+++ b/ops/c/src/externlib/ops_hdf5.c
@@ -286,8 +286,9 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
   if (block->dims == 1)
     g_size[0] = g_size[0] * dat->dim; // -- this needs to be tested for 1D
   else if (block->dims == 2)
-    g_size[1] =
-        g_size[1] * dat->dim; //**note we are using [1] instead of [0] here !!
+  //Jianping Meng: it looks that growing the zero index is better
+    g_size[0] =
+        g_size[0] * dat->dim; //**note we are using [1] instead of [0] here !!
   else if (block->dims == 3) {
     g_size[0] =
         g_size[0] * dat->dim; //**note that for 3D we are using [0] here !!

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -586,17 +586,28 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
     // make sure we multiply by the number of data values per
     // element (i.e. dat->dim) to get full size of the data
-    size[0] = size[0] * dat->dim;
-    disp[0] = disp[0] * dat->dim;
-
     if (block->dims == 1)
-      gbl_size[0] = gbl_size[0] * dat->dim; //-- this needs to be tested for 1D
-    else if (block->dims == 2)
-      gbl_size[1] = gbl_size[1] *
-                    dat->dim; //**note we are using [1] instead of [0] here !!
-    else if (block->dims == 3)
-      gbl_size[0] =
-          gbl_size[0] * dat->dim; //**note that for 3D we are using [0] here !!
+     {
+       gbl_size[0] = gbl_size[0] * dat->dim; //-- this needs to be tested for 1D
+       size[0] = size[0] * dat->dim;
+       disp[0] = disp[0] * dat->dim;
+     }
+     else if (block->dims == 2)
+     {
+       //Jianping Meng: I found that growing the dim 0 rather than dim 1 can lead
+       //to a more consistent post-processing procedure for multi-dim data
+       //**note we are using [1] instead of [0] here !!
+       gbl_size[0] = gbl_size[0] * dat->dim;
+       size[0] = size[0] * dat->dim;
+       disp[0] = disp[0] * dat->dim;
+     }
+     else if (block->dims == 3)
+     {
+       gbl_size[0] =
+           gbl_size[0] * dat->dim; //**note that for 3D we are using [0] here !!
+       size[0] = size[0] * dat->dim;
+       disp[0] = disp[0] * dat->dim;
+     }
 
     // MPI variables
     MPI_Info info = MPI_INFO_NULL;
@@ -905,7 +916,7 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
       }
 
       memspace = H5Screate_simple(
-          block->dims, size,
+          block->dims, SIZE,
           NULL); // block of memory to write to file by each proc
 
       // Select hyperslab

--- a/ops/c/src/mpi/ops_mpi_hdf5.c
+++ b/ops/c/src/mpi/ops_mpi_hdf5.c
@@ -586,11 +586,11 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
 
     // make sure we multiply by the number of data values per
     // element (i.e. dat->dim) to get full size of the data
+    size[0] = size[0] * dat->dim;
+    disp[0] = disp[0] * dat->dim;
     if (block->dims == 1)
      {
        gbl_size[0] = gbl_size[0] * dat->dim; //-- this needs to be tested for 1D
-       size[0] = size[0] * dat->dim;
-       disp[0] = disp[0] * dat->dim;
      }
      else if (block->dims == 2)
      {
@@ -598,15 +598,11 @@ void ops_fetch_dat_hdf5_file(ops_dat dat, char const *file_name) {
        //to a more consistent post-processing procedure for multi-dim data
        //**note we are using [1] instead of [0] here !!
        gbl_size[0] = gbl_size[0] * dat->dim;
-       size[0] = size[0] * dat->dim;
-       disp[0] = disp[0] * dat->dim;
      }
      else if (block->dims == 3)
      {
        gbl_size[0] =
            gbl_size[0] * dat->dim; //**note that for 3D we are using [0] here !!
-       size[0] = size[0] * dat->dim;
-       disp[0] = disp[0] * dat->dim;
      }
 
     // MPI variables
@@ -1552,7 +1548,8 @@ void ops_read_dat_hdf5(ops_dat dat) {
     if (block->dims == 1)
       gbl_size[0] = gbl_size[0] * dat->dim; //-- this needs to be tested for 1D
     else if (block->dims == 2)
-      gbl_size[1] = gbl_size[1] *
+     //Jianping Meng: It looks that growing the zeroth index  is better
+      gbl_size[0] = gbl_size[0] *
                     dat->dim; //**note we are using [1] instead of [0] here !!
     else if (block->dims == 3)
       gbl_size[0] =

--- a/scripts/source_intel
+++ b/scripts/source_intel
@@ -25,13 +25,13 @@ module load intel-compilers
 module load intel-mpi
 export MPI_INSTALL_PATH=/opt/compilers/intel/intelPS-2015/impi/5.0.3.048/intel64/
 #export MPI_INSTALL_PATH=/home/mgiles/mudalige/mvapich2/intel-15
-#source /opt/compilers/intel/intelPS-2015/composerxe/bin/compilervars.sh intel64
-#source /opt/compilers/intel/intelPS-2015/impi_latest/intel64/bin/mpivars.sh intel64
+source /opt/compilers/intel/intelPS-2015/composerxe/bin/compilervars.sh intel64
+source /opt/compilers/intel/intelPS-2015/impi_latest/intel64/bin/mpivars.sh intel64
 
-#export INTEL_PATH=/opt/compilers/intel/intelPS-2015/composerxe/
-#export MPICH_CXX=/opt/compilers/intel/intelPS-2015/composerxe/bin/icpc
-#export MPICH_CC=/opt/compilers/intel/intelPS-2015/composerxe/bin/icc
-#export MPICH_F90=/opt/compilers/intel/intelPS-2015/composerxe/bin/ifort
+export INTEL_PATH=/opt/compilers/intel/intelPS-2015/composerxe/
+export MPICH_CXX=/opt/compilers/intel/intelPS-2015/composerxe/bin/icpc
+export MPICH_CC=/opt/compilers/intel/intelPS-2015/composerxe/bin/icc
+export MPICH_F90=/opt/compilers/intel/intelPS-2015/composerxe/bin/ifort
 
 #Intel based HDF5
 #unset HDF5_INSTALL_PATH


### PR DESCRIPTION
The fixed issue causing the following complaints from HDF5 routines:
h5dwrite(): file selection+offset not within extent
and then the HDF5 routine refuses to write the actual data.