### PR TITLE
Fixing hdf5 error in writing to a file by temporarily removing aligned memory allocation for an ops_dat

### DIFF
--- a/apps/c/CloverLeaf_3D_HDF5/test.sh
+++ b/apps/c/CloverLeaf_3D_HDF5/test.sh
@@ -16,7 +16,7 @@ rm *.h5
 $MPI_INSTALL_PATH/bin/mpirun -np 10 ./generate_file_mpi
 
 #============================ Test Cloverleaf 3D With Intel Compilers==========================================================
-<<COMMENT
+#<<COMMENT
 echo '============> Running OpenMP'
 KMP_AFFINITY=compact OMP_NUM_THREADS=20 ./cloverleaf_openmp > perf_out
 grep "Total Wall time" clover.out
@@ -115,7 +115,7 @@ rm perf_out
 
 echo "All Intel complied applications PASSED : Exiting Test Script "
 
-COMMENT
+#COMMENT
 cd -
 source ../../scripts/source_pgi_15.10
 
@@ -124,7 +124,7 @@ make
 cd -
 make
 
-<<COMMENT0
+#<<COMMENT0
 #============================ Test Cloverleaf 3D With PGI Compilers==========================================================
 echo '============> Running OpenMP'
 KMP_AFFINITY=compact OMP_NUM_THREADS=20 ./cloverleaf_openmp > perf_out
@@ -219,7 +219,7 @@ rc=$?; if [[ $rc != 0 ]]; then echo "TEST FAILED";exit $rc; fi
 rm -f clover.out
 rm perf_out
 
-COMMENT0
+#COMMENT0
 
 echo '============> Running OpenACC'
 ./cloverleaf_openacc OPS_BLOCK_SIZE_X=64 OPS_BLOCK_SIZE_Y=4 > perf_out

--- a/ops/c/src/sequential/ops_seq.c
+++ b/ops/c/src/sequential/ops_seq.c
@@ -38,8 +38,7 @@
 #include <ops_lib_core.h>
 char *ops_halo_buffer = NULL;
 int ops_halo_buffer_size = 0;
-int posix_memalign(void **memptr, size_t alignment, size_t size); 
-
+int posix_memalign(void **memptr, size_t alignment, size_t size);
 
 void ops_init(int argc, char **argv, int diags) {
   ops_init_core(argc, argv, diags);
@@ -66,16 +65,18 @@ ops_dat ops_decl_dat_char(ops_block block, int size, int *dat_size, int *base,
   } else {
     // Allocate memory immediately
     int bytes = size * type_size;
-#ifdef __INTEL_COMPILER
-    //On intel, make x size a multiple of 128 bytes by extending d_p
-    int oldsize = dat->size[0];
-    //Compute least common multiple - type_size is a multiple of 2, I need to remove all factors of 2 from size
-    int size_non_2 = size;
-    while (size_non_2%2==0 && size>1) size_non_2 /= 2;
-    int least_common_multiple = 128/type_size * size_non_2;
-    dat->size[0] = ((dat->size[0]-1)/(least_common_multiple )+1)*least_common_multiple;
-    dat->d_p[0] += (dat->size[0] - oldsize);
-#endif
+    /*#ifdef __INTEL_COMPILER
+        //On intel, make x size a multiple of 128 bytes by extending d_p
+        int oldsize = dat->size[0];
+        //Compute least common multiple - type_size is a multiple of 2, I need
+    to remove all factors of 2 from size
+        int size_non_2 = size;
+        while (size_non_2%2==0 && size>1) size_non_2 /= 2;
+        int least_common_multiple = 128/type_size * size_non_2;
+        dat->size[0] = ((dat->size[0]-1)/(least_common_multiple
+    )+1)*least_common_multiple;
+        dat->d_p[0] += (dat->size[0] - oldsize);
+    #endif*/
     for (int i = 0; i < block->dims; i++)
       bytes = bytes * dat->size[i];
 #ifdef __INTEL_COMPILER


### PR DESCRIPTION
This is a temporary fix for an HDF5 error causing MPI to abort when writing to an HDF5 file created by a non-mpi version of an application. Basically the cause is differences in a data set's attributes due to recalculating them after doing aligned memory allocations in ops_seq.c

As the aligned memory allocations are critical for the TDMA work a longer term solution is needed. But for now the above fix should be enough for the master branch to work correctly. 